### PR TITLE
Fixes the NoUnimportedPromise rule to not flag local Promise variable declarations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added the `comma-spacing`, `keyword-spacing`, `no-multi-spaces`, `space-infix-ops` and `space-unary-ops` rules to the default ruleset.
 
+### Fixed
+
+- Fixed the `@tinymce/no-unimported-promise` incorrectly detecting local variables.
+
 ## [1.1.0] - 2020-03-16
 
 ### Changed

--- a/src/main/ts/rules/NoUnimportedPromise.ts
+++ b/src/main/ts/rules/NoUnimportedPromise.ts
@@ -60,7 +60,7 @@ export const noUnimportedPromise: Rule.RuleModule = {
             if (callee.name === 'Promise') {
               if (!seenPromiseImport && !hasPromiseInScope(context)) {
                 context.report({
-                  node,
+                  node: callee,
                   messageId: 'promiseFillMissing',
                 });
               }

--- a/src/test/rules/NoUnimportedPromiseTest.ts
+++ b/src/test/rules/NoUnimportedPromiseTest.ts
@@ -46,6 +46,21 @@ ruleTester.run('no-unimported-promise', noUnimportedPromise, {
     {
       code: 'const b = new Promise((resolve) => {});',
       errors: [{ message: 'Promise needs a featurefill import since IE 11 doesn\'t have native support.' }],
+    },
+    {
+      code: `
+      const fn = function() {
+        const Promise = function() { return {}; };
+        const c = new Promise();
+        const d = Promise.resolve();
+      };
+      const e = new Promise();
+      const f = Promise.resolve();
+      `,
+      errors: [
+        { line: 7, message: 'Promise needs a featurefill import since IE 11 doesn\'t have native support.' },
+        { line: 8, message: 'Promise needs a featurefill import since IE 11 doesn\'t have native support.' }
+      ]
     }
   ]
 });

--- a/src/test/rules/NoUnimportedPromiseTest.ts
+++ b/src/test/rules/NoUnimportedPromiseTest.ts
@@ -22,6 +22,20 @@ ruleTester.run('no-unimported-promise', noUnimportedPromise, {
       code: 'const c = SomethingElse.resolve();'
     }, {
       code: 'const d = new SomethingElse();'
+    }, {
+      code: `
+      const Promise = function() { return {}; };
+      
+      const e = new Promise();
+      const f = Promise.resolve();
+      `
+    }, {
+      code: `
+      const Promise = () => ({}) as unknown as PromiseConstructor;
+      
+      const g = new Promise();
+      const h = Promise.resolve();
+      `
     }
   ],
   invalid: [


### PR DESCRIPTION
We disabled this in TinyMCE as it was picking up custom `Promise` implementations, so this adds a fix so it doesn't detect them as invalid.

Note: I've also tested this against the TinyMCE repo.