### PR TITLE
TINY-6267: Fixed broken linting rules

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed the `@tinymce/no-unimported-promise` incorrectly detecting local variables.
+- Fixed the `@tinymce/no-enums-in-export-specifier` detecting built-in object properties.
 
 ## [1.2.0] - 2020-04-06
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added the `@typescript-eslint/keyword-spacing`, `comma-spacing`, `no-multi-spaces`, `space-infix-ops` and `space-unary-ops` rules to the default ruleset.
 
+### Fixed
+
+- Fixed the `@tinymce/no-unimported-promise` incorrectly detecting local variables.
+
 ## [1.2.0] - 2020-04-06
 
 ## [1.1.0] - 2020-03-16

--- a/src/main/ts/rules/NoEnumsInExportSpecifier.ts
+++ b/src/main/ts/rules/NoEnumsInExportSpecifier.ts
@@ -20,7 +20,8 @@ export const noEnumsInExportSpecifier: Rule.RuleModule = {
       },
       ExportSpecifier: (node) => {
         if (node.type === 'ExportSpecifier') {
-          if (enumNames[node.local.name]) {
+          const name = node.local.name;
+          if (enumNames.hasOwnProperty(name) && enumNames[name]) {
             context.report({ node, messageId: 'noEnumsInExportSpecifier' });
           }
         }

--- a/src/main/ts/rules/NoUnimportedPromise.ts
+++ b/src/main/ts/rules/NoUnimportedPromise.ts
@@ -60,7 +60,7 @@ export const noUnimportedPromise: Rule.RuleModule = {
             if (callee.name === 'Promise') {
               if (!seenPromiseImport && !hasPromiseInScope(context)) {
                 context.report({
-                  node,
+                  node: callee,
                   messageId: 'promiseFillMissing',
                 });
               }

--- a/src/test/rules/NoEnumsInExportSpecifierTest.ts
+++ b/src/test/rules/NoEnumsInExportSpecifierTest.ts
@@ -24,6 +24,15 @@ ruleTester.run('no-enums-in-export-specifier', noEnumsInExportSpecifier, {
         NotEnum
       };
       `
+    },
+    {
+      code: `
+      const isPrototypeOf = 'a';
+
+      export {
+        isPrototypeOf
+      };
+      `
     }
   ],
 

--- a/src/test/rules/NoUnimportedPromiseTest.ts
+++ b/src/test/rules/NoUnimportedPromiseTest.ts
@@ -22,6 +22,18 @@ ruleTester.run('no-unimported-promise', noUnimportedPromise, {
       code: 'const c = SomethingElse.resolve();'
     }, {
       code: 'const d = new SomethingElse();'
+    }, {
+      code: `
+      const Promise = function() { return {}; };
+      const e = new Promise();
+      const f = Promise.resolve();
+      `
+    }, {
+      code: `
+      const Promise = () => ({}) as unknown as PromiseConstructor;
+      const g = new Promise();
+      const h = Promise.resolve();
+      `
     }
   ],
   invalid: [

--- a/src/test/rules/NoUnimportedPromiseTest.ts
+++ b/src/test/rules/NoUnimportedPromiseTest.ts
@@ -44,6 +44,21 @@ ruleTester.run('no-unimported-promise', noUnimportedPromise, {
     {
       code: 'const b = new Promise((resolve) => {});',
       errors: [{ message: 'Promise needs a featurefill import since IE 11 doesn\'t have native support.' }],
+    },
+    {
+      code: `
+      const fn = function() {
+        const Promise = function() { return {}; };
+        const c = new Promise();
+        const d = Promise.resolve();
+      };
+      const e = new Promise();
+      const f = Promise.resolve();
+      `,
+      errors: [
+        { line: 7, message: 'Promise needs a featurefill import since IE 11 doesn\'t have native support.' },
+        { line: 8, message: 'Promise needs a featurefill import since IE 11 doesn\'t have native support.' }
+      ]
     }
   ]
 });


### PR DESCRIPTION
This fixes the `no-enums-in-export-specifier` and `no-unimported-promise` rules, as they were picking up things they shouldn't have. For the former, it was picking up built-in object properties such as `valueOf` and for the former, it was picking up `Promise` usages that pointed to a locally declared variable.