### PR TITLE
TINY-3785: Added new `@tinymce/no-implicit-dom-globals` rule to prevent dom global variables being used implicitly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0] - 2020-07-27
+
+### Added
+
+- Added new `@tinymce/no-implicit-dom-globals` rule to prevent dom global variables being used implicitly.
+
 ## [1.3.0] - 2020-07-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.js",
@@ -11,16 +11,18 @@
     "@typescript-eslint/parser": "^2.29.0",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-prefer-arrow": "^1.1.7"
+    "eslint-plugin-prefer-arrow": "^1.1.7",
+    "resolve": "^1.10.0",
+    "typescript": "^3.8.0"
   },
   "devDependencies": {
     "@types/eslint": "^6.1.8",
     "@types/estree": "^0.0.42",
     "@types/node": "^13.9.0",
+    "@types/resolve": "^1.17.1",
     "@typescript-eslint/typescript-estree": "^2.29.0",
     "jest": "^25.1.0",
-    "ts-jest": "^25.2.1",
-    "typescript": "^3.8.3"
+    "ts-jest": "^25.2.1"
   },
   "files": [
     "dist/main",

--- a/src/main/ts/api/Main.ts
+++ b/src/main/ts/api/Main.ts
@@ -2,6 +2,7 @@ import { Linter, Rule } from 'eslint';
 import { standard } from '../configs/Standard';
 import { noDirectImports } from '../rules/NoDirectImports';
 import { noEnumsInExportSpecifier } from '../rules/NoEnumsInExportSpecifier';
+import { noImplicitDomGlobals } from '../rules/NoImplicitDomGlobals';
 import { noMainModuleImports } from '../rules/NoMainModuleImports';
 import { noPathAliasImports } from '../rules/NoPathAliasImports';
 import { noUnimportedPromise } from '../rules/NoUnimportedPromise';
@@ -11,7 +12,8 @@ const rules: Record<string, Rule.RuleModule> = {
   'no-enums-in-export-specifier': noEnumsInExportSpecifier,
   'no-main-module-imports': noMainModuleImports,
   'no-path-alias-imports': noPathAliasImports,
-  'no-unimported-promise': noUnimportedPromise
+  'no-unimported-promise': noUnimportedPromise,
+  'no-implicit-dom-globals': noImplicitDomGlobals
 };
 
 const configs: Record<string, Linter.Config> = {

--- a/src/main/ts/configs/Standard.ts
+++ b/src/main/ts/configs/Standard.ts
@@ -116,5 +116,6 @@ export const standard: Linter.Config = {
     '@tinymce/no-main-module-imports': 'error',
     '@tinymce/no-path-alias-imports': 'error',
     '@tinymce/no-unimported-promise': 'error',
+    '@tinymce/no-implicit-dom-globals': 'error',
   }
 };

--- a/src/main/ts/rules/NoImplicitDomGlobals.ts
+++ b/src/main/ts/rules/NoImplicitDomGlobals.ts
@@ -1,0 +1,144 @@
+import { Rule } from 'eslint';
+import { Identifier, Node, VariableDeclarator } from 'estree';
+import * as Globals from '../utils/Globals';
+import * as NewOrCallUtils from '../utils/NewOrCallUtils';
+import { hasVariableInScope } from '../utils/ScopeUtils';
+
+interface Options {
+  allowed: string[];
+  appendDefaults: boolean;
+}
+
+const defaultExceptions = [
+  'window',
+  'document',
+  'console',
+  'navigator',
+  'localStorage',
+  'sessionStorage',
+
+  // Common functions
+  'atob',
+  'clearTimeout',
+  'setTimeout',
+  'clearInterval',
+  'setInterval',
+
+  // Commons constructors
+  'Blob',
+  'DOMParser',
+  'FileReader',
+  'FormData',
+  'MutationObserver',
+  'Image',
+  'URL',
+  'XMLHttpRequest',
+
+  // Common property accessors
+  'Node',
+
+  // Common events
+  'Event',
+  'KeyboardEvent',
+  'MouseEvent',
+  'Touch',
+  'TouchEvent',
+  'UIEvent'
+];
+
+const getAllowedGlobals = (options: Partial<Options>): string[] => {
+  const allowedGlobals = options.allowed || [];
+  if (options.appendDefaults) {
+    return allowedGlobals.concat(defaultExceptions);
+  } else {
+    return options.allowed === undefined ? defaultExceptions : allowedGlobals;
+  }
+};
+
+const extractInitIdentifier = (node: VariableDeclarator): Identifier | null => {
+  const init = node.init;
+  if (init) {
+    // a = Node.DOCUMENT_POSITION_PRECEDING
+    if (init.type === 'MemberExpression') {
+      const object = init.object;
+      if (object.type === 'Identifier') {
+        return object;
+      }
+    }
+
+    // a = Node
+    if (init.type === 'Identifier') {
+      return init;
+    }
+  }
+
+  return null;
+};
+
+
+export const noImplicitDomGlobals: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallows implicit dom global variables from being used without being accessed via the global window object. ' +
+                   'A number of common ones are allowed by default however, such as window and document.'
+    },
+    messages: {
+      noImplicitDomGlobals: 'Don\'t use implicit dom globals. Access the global via the window object instead.'
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowed: {
+            type: 'array',
+            items: {
+              type: 'string'
+            }
+          },
+          appendDefaults: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+  create: (context) => {
+    const options = context.options[0] || {};
+    const allowed = getAllowedGlobals(options);
+    const invalid = Globals.getDomGlobals().filter((name) => !allowed.includes(name));
+
+    const report = (node: Node) => {
+      context.report({
+        node: node,
+        messageId: 'noImplicitDomGlobals',
+        fix: (fixer: Rule.RuleFixer): Rule.Fix => {
+          return fixer.insertTextBefore(node, 'window.');
+        }
+      });
+    };
+
+    return {
+      VariableDeclarator: (node) => {
+        if (node.type === 'VariableDeclarator' && node.init) {
+          let identifier = extractInitIdentifier(node);
+          if (identifier) {
+            const name = identifier.name;
+            if (invalid.includes(name) && !hasVariableInScope(context, name)) {
+              report(identifier);
+            }
+          }
+        }
+      },
+      ...NewOrCallUtils.forIdentifier((node, identifier) => {
+        const name = identifier.name;
+        if (invalid.includes(name) && !hasVariableInScope(context, name)) {
+          const callee = node.type === 'NewExpression' ? identifier : node;
+          report(callee);
+        }
+      })
+    };
+  }
+};

--- a/src/main/ts/utils/Globals.ts
+++ b/src/main/ts/utils/Globals.ts
@@ -1,0 +1,50 @@
+import * as path from 'path';
+import * as resolve from 'resolve';
+import * as ts from 'typescript';
+
+const globalsCache: Record<string, any> = {};
+
+const getVariableExportList = (ast: ts.SourceFile) => {
+  const vars: string[] = [];
+
+  const addVariable = (node: ts.Node) => {
+    const name = (node as any).name;
+    if (name && name.kind === ts.SyntaxKind.Identifier) {
+      vars.push(name.escapedText);
+    }
+  };
+
+  ts.forEachChild(ast, (node) => {
+    switch (node.kind) {
+      case ts.SyntaxKind.FunctionDeclaration:
+      case ts.SyntaxKind.MethodDeclaration:
+      case ts.SyntaxKind.PropertyDeclaration:
+        addVariable(node);
+        break;
+
+      case ts.SyntaxKind.VariableStatement:
+        const statement = node as ts.VariableStatement;
+        statement.declarationList.declarations.forEach((node) => {
+          addVariable(node);
+        });
+        break;
+    }
+  });
+  return vars;
+};
+
+export const getDomGlobals = (): string[] => {
+  if (!globalsCache.hasOwnProperty('dom')) {
+    // Resolve the path to the TS dom library types
+    const resolved = resolve.sync('typescript');
+    const domLib = path.join(path.dirname(resolved), 'lib.dom.d.ts');
+
+    // Parse the types
+    const prog = ts.createProgram([ domLib ], {});
+    const ast = prog.getSourceFile(domLib);
+
+    // Extract the variables and cache the dom globals lookup
+    globalsCache['dom'] = ast ? getVariableExportList(ast) : [];
+  }
+  return globalsCache['dom'];
+};

--- a/src/main/ts/utils/NewOrCallUtils.ts
+++ b/src/main/ts/utils/NewOrCallUtils.ts
@@ -1,0 +1,28 @@
+import { Rule } from 'eslint';
+import { CallExpression, Identifier, NewExpression } from 'estree';
+
+export const forIdentifier = (f: (node: CallExpression | NewExpression, identifier: Identifier) => void): Rule.RuleListener => {
+  return {
+    CallExpression: (node) => {
+      if (node.type === 'CallExpression') {
+        const callee = node.callee;
+        if (callee.type === 'MemberExpression') {
+          const object = callee.object;
+          if (object.type === 'Identifier') {
+            f(node, object);
+          }
+        } else if (callee.type === 'Identifier') {
+          f(node, callee);
+        }
+      }
+    },
+    NewExpression: (node) => {
+      if (node.type === 'NewExpression') {
+        const callee = node.callee;
+        if (callee.type === 'Identifier') {
+          f(node, callee);
+        }
+      }
+    }
+  }
+};

--- a/src/main/ts/utils/ScopeUtils.ts
+++ b/src/main/ts/utils/ScopeUtils.ts
@@ -1,0 +1,13 @@
+import { Rule, Scope } from 'eslint';
+import { exists } from './Arr';
+
+export const hasVariableInScope = (context: Rule.RuleContext, name: string) => {
+  let scope: Scope.Scope | null = context.getScope();
+  while (scope && scope.type !== 'global') {
+    if (exists(scope.variables, (v) => v.name === name)) {
+      return true;
+    }
+    scope = scope.upper;
+  }
+  return false;
+};

--- a/src/test/rules/NoImplicitDomGlobalsTest.ts
+++ b/src/test/rules/NoImplicitDomGlobalsTest.ts
@@ -1,0 +1,59 @@
+import { RuleTester } from 'eslint';
+import { noImplicitDomGlobals } from '../../main/ts/rules/NoImplicitDomGlobals';
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: { sourceType: 'module' }
+});
+
+ruleTester.run('no-implicit-dom-globals', noImplicitDomGlobals, {
+  valid: [
+    {
+      code: 'const a = new Blob([ "a" ]);'
+    },
+    {
+      code: 'const b = window.name;'
+    },
+    {
+      code: 'const c = window.fetch("url", {});'
+    },
+    {
+      code: 'const d = Node.DOCUMENT_POSITION_PRECEDING;',
+    },
+    {
+      code: 'window.history.pushState({}, "", "url");'
+    }
+  ],
+  invalid: [
+    {
+      code: 'const a = name;',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const a = window.name;'
+    },
+    {
+      code: 'const b = HTMLElement.prototypeOf("");',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const b = window.HTMLElement.prototypeOf("");'
+    },
+    {
+      code: 'const c = fetch("url", { });',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const c = window.fetch("url", { });'
+    },
+    {
+      code: 'const d = Element.DOCUMENT_POSITION_PRECEDING;',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const d = window.Element.DOCUMENT_POSITION_PRECEDING;'
+    },
+    {
+      code: 'const e = new URLSearchParams();',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const e = new window.URLSearchParams();'
+    },
+    {
+      code: 'history.pushState({}, "", "url");',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'window.history.pushState({}, "", "url");'
+    },
+  ]
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,10 +413,22 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/node@*":
+  version "14.0.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.24.tgz#b0f86f58564fa02a28b68f8b55d4cdec42e3b9d6"
+  integrity sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
+
 "@types/node@^13.9.0":
   version "13.9.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.0.tgz#5b6ee7a77faacddd7de719017d0bc12f52f81589"
   integrity sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==
+
+"@types/resolve@^1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -3884,10 +3896,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.8.0:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This adds a new linter rule to prevent dom globals being implicitly used, with the exception of a whitelist we allow by default. This new rule comes with the following 2 options to allow it to be customized per project:
- `allowed`: a string array of dom global variable names to allow
- `appendDefault`: Whether or not to append the allowed variables to the default allowed variables. Defaults to false.