### PR TITLE
TINY-6504: Fixed some dom-globals not flagged as invalid when using the `@tinymce/no-implicit-dom-globals` rule

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.2] - 2020-12-08
+
+### Fixed
+- Some dom-globals weren't flagged as invalid when using the `@tinymce/no-implicit-dom-globals` rule. 
+
 ## [1.5.0] - 2020-10-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "lint": "eslint src/**/*.ts",
     "test": "jest",
     "prepublishOnly": "tsc"
+  },
+  "engines": {
+    "node": ">=9.0.0"
   }
 }

--- a/src/main/ts/rules/NoImplicitDomGlobals.ts
+++ b/src/main/ts/rules/NoImplicitDomGlobals.ts
@@ -1,5 +1,5 @@
 import { Rule } from 'eslint';
-import { Identifier, Node, Property, VariableDeclarator } from 'estree';
+import { Expression, Identifier, Node, Property, VariableDeclarator } from 'estree';
 import { extractIdentifier } from '../utils/ExtractUtils';
 import * as Globals from '../utils/Globals';
 import * as NewOrCallUtils from '../utils/NewOrCallUtils';
@@ -132,6 +132,15 @@ export const noImplicitDomGlobals: Rule.RuleModule = {
         if (node.type === 'ExpressionStatement') {
           const identifier = extractIdentifier(node.expression);
           validateIdentifier(identifier);
+        }
+      },
+      'AssignmentExpression,BinaryExpression': (node: Expression) => {
+        if (node.type === 'AssignmentExpression' || node.type === 'BinaryExpression') {
+          const leftIdentifier = extractIdentifier(node.left);
+          validateIdentifier(leftIdentifier);
+
+          const rightIdentifier = extractIdentifier(node.right);
+          validateIdentifier(rightIdentifier);
         }
       },
       ConditionalExpression: (node) => {

--- a/src/main/ts/utils/ExtractUtils.ts
+++ b/src/main/ts/utils/ExtractUtils.ts
@@ -1,4 +1,4 @@
-import { Node } from 'estree';
+import { Expression, Identifier, Node, Pattern, SpreadElement, Super } from 'estree';
 
 export const extractModuleSpecifier = (node: Node) => {
   if (node.type === 'ImportDeclaration') {
@@ -8,4 +8,22 @@ export const extractModuleSpecifier = (node: Node) => {
     }
   }
   return '';
+};
+
+export const extractIdentifier = (node: Expression | Super | SpreadElement | Pattern): Identifier | null => {
+  // Node
+  if (node.type === 'Identifier') {
+    return node;
+    // Node.DOCUMENT_POSITION_PRECEDING
+  } else if (node.type === 'MemberExpression') {
+    return extractIdentifier(node.object);
+    // a = Node
+  } else if (node.type === 'AssignmentExpression') {
+    return extractIdentifier(node.right);
+    // ...Node
+  } else if (node.type === 'SpreadElement') {
+    return extractIdentifier(node.argument);
+  }
+
+  return null;
 };

--- a/src/main/ts/utils/ExtractUtils.ts
+++ b/src/main/ts/utils/ExtractUtils.ts
@@ -17,9 +17,6 @@ export const extractIdentifier = (node: Expression | Super | SpreadElement | Pat
     // Node.DOCUMENT_POSITION_PRECEDING
   } else if (node.type === 'MemberExpression') {
     return extractIdentifier(node.object);
-    // a = Node
-  } else if (node.type === 'AssignmentExpression') {
-    return extractIdentifier(node.right);
     // ...Node
   } else if (node.type === 'SpreadElement') {
     return extractIdentifier(node.argument);

--- a/src/main/ts/utils/NewOrCallUtils.ts
+++ b/src/main/ts/utils/NewOrCallUtils.ts
@@ -1,27 +1,35 @@
 import { Rule } from 'eslint';
 import { CallExpression, Identifier, NewExpression } from 'estree';
+import { extractIdentifier } from './ExtractUtils';
 
-export const forIdentifier = (f: (node: CallExpression | NewExpression, identifier: Identifier) => void): Rule.RuleListener => {
+export const forIdentifier = (f: (node: CallExpression | NewExpression | Identifier, identifier: Identifier) => void): Rule.RuleListener => {
+  const checkCallee = (node: CallExpression | NewExpression) => {
+    const identifier = extractIdentifier(node.callee);
+    if (identifier !== null) {
+      f(node, identifier);
+    }
+  };
+
+  const checkArguments = (node: CallExpression | NewExpression) => {
+    node.arguments.forEach((arg) => {
+      const identifier = extractIdentifier(arg);
+      if (identifier !== null) {
+        f(identifier, identifier);
+      }
+    });
+  };
+
   return {
     CallExpression: (node) => {
       if (node.type === 'CallExpression') {
-        const callee = node.callee;
-        if (callee.type === 'MemberExpression') {
-          const object = callee.object;
-          if (object.type === 'Identifier') {
-            f(node, object);
-          }
-        } else if (callee.type === 'Identifier') {
-          f(node, callee);
-        }
+        checkCallee(node);
+        checkArguments(node);
       }
     },
     NewExpression: (node) => {
       if (node.type === 'NewExpression') {
-        const callee = node.callee;
-        if (callee.type === 'Identifier') {
-          f(node, callee);
-        }
+        checkCallee(node);
+        checkArguments(node);
       }
     }
   }

--- a/src/test/rules/NoImplicitDomGlobalsTest.ts
+++ b/src/test/rules/NoImplicitDomGlobalsTest.ts
@@ -55,5 +55,50 @@ ruleTester.run('no-implicit-dom-globals', noImplicitDomGlobals, {
       errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
       output: 'window.history.pushState({}, "", "url");'
     },
+    {
+      code: `
+      const f = (str: string): void => {};
+      f(name);
+      `,
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: `
+      const f = (str: string): void => {};
+      f(window.name);
+      `
+    },
+    {
+      code: `
+      let g: string;
+      g = name;
+      `,
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: `
+      let g: string;
+      g = window.name;
+      `
+    },
+    {
+      code: 'const h = [ name ];',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const h = [ window.name ];'
+    },
+    {
+      code: 'const i = { test: name };',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'const i = { test: window.name };'
+    },
+    {
+      code: 'return location.href;',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'return window.location.href;'
+    },
+    {
+      code: 'const j = a ? name : location.href;',
+      errors: [
+        { message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' },
+        { message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }
+      ],
+      output: 'const j = a ? window.name : window.location.href;'
+    },
   ]
 });

--- a/src/test/rules/NoImplicitDomGlobalsTest.ts
+++ b/src/test/rules/NoImplicitDomGlobalsTest.ts
@@ -100,5 +100,10 @@ ruleTester.run('no-implicit-dom-globals', noImplicitDomGlobals, {
       ],
       output: 'const j = a ? window.name : window.location.href;'
     },
+    {
+      code: 'HTMLInputElement.prototype.click = props.click;',
+      errors: [{ message: 'Don\'t use implicit dom globals. Access the global via the window object instead.' }],
+      output: 'window.HTMLInputElement.prototype.click = props.click;'
+    }
   ]
 });

--- a/src/test/rules/NoImplicitDomGlobalsTest.ts
+++ b/src/test/rules/NoImplicitDomGlobalsTest.ts
@@ -22,6 +22,13 @@ ruleTester.run('no-implicit-dom-globals', noImplicitDomGlobals, {
     },
     {
       code: 'window.history.pushState({}, "", "url");'
+    },
+    {
+      code: `
+      const f = (str: string): void => {};
+      const name = 'Test';
+      f(name);
+      `
     }
   ],
   invalid: [


### PR DESCRIPTION
I've noticed over time that I'd missed a number of cases for the `no-implicit-dom-globals` rule, so this fixes them and makes a small performance improvement. I'm doing this in preparation of using ESLint in the premium plugins.

Note: This does cause 6 failures to appear in TinyMCE due to it now picking up things like `HTMLCanvasElement.prototype` in call expression arguments.
```
@ephox/imagetools: /home/lnewson/git/tinymce/modules/imagetools/src/main/ts/ephox/imagetools/util/Conversions.ts
@ephox/imagetools:   137:23  error  Don't use implicit dom globals. Access the global via the window object instead  @tinymce/no-implicit-dom-globals
@ephox/imagetools: ✖ 1 problem (1 error, 0 warnings)
@ephox/imagetools:   1 error and 0 warnings potentially fixable with the `--fix` option.
@ephox/sugar: /home/lnewson/git/tinymce/modules/sugar/src/main/ts/ephox/sugar/api/node/SugarShadowDom.ts
@ephox/sugar:   19:19  error  Don't use implicit dom globals. Access the global via the window object instead  @tinymce/no-implicit-dom-globals
@ephox/sugar: ✖ 1 problem (1 error, 0 warnings)
@ephox/sugar:   1 error and 0 warnings potentially fixable with the `--fix` option.
@ephox/agar: /home/lnewson/git/tinymce/modules/agar/src/main/ts/ephox/agar/file/PatchInputFiles.ts
@ephox/agar:   33:44  error  Don't use implicit dom globals. Access the global via the window object instead  @tinymce/no-implicit-dom-globals
@ephox/agar:   34:12  error  Don't use implicit dom globals. Access the global via the window object instead  @tinymce/no-implicit-dom-globals
@ephox/agar:   39:25  error  Don't use implicit dom globals. Access the global via the window object instead  @tinymce/no-implicit-dom-globals
@ephox/agar:   50:27  error  Don't use implicit dom globals. Access the global via the window object instead  @tinymce/no-implicit-dom-globals
@ephox/agar: ✖ 4 problems (4 errors, 0 warnings)
@ephox/agar:   4 errors and 0 warnings potentially fixable with the `--fix` option.

```