### PR TITLE
TINY-6504: Enabled the `brace-style` rule and fixed an issue with the `prefer-fun` rule not picking up `Fun.constant(true)`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7.0] - 2020-10-16
+
+### Changed
+- Enabled the `brace-style` rule to ensure code cannot be on the same line as if/else statements.
+
+### Fixed
+- `Fun.constant(false)` was not detected as syntax that should be replaced by `Fun.never`.
+
 ## [1.6.0] - 2020-10-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.js",

--- a/src/main/ts/configs/Standard.ts
+++ b/src/main/ts/configs/Standard.ts
@@ -79,6 +79,7 @@ export const base: Linter.Config = {
     'arrow-body-style': 'error',
     'arrow-parens': [ 'error', 'always' ],
     'arrow-spacing': 'error',
+    'brace-style': 'error',
     'comma-dangle': 'off',
     'complexity': 'off',
     'constructor-super': 'error',

--- a/src/main/ts/rules/PreferFun.ts
+++ b/src/main/ts/rules/PreferFun.ts
@@ -1,6 +1,7 @@
 import { Rule } from 'eslint';
 import { ArrowFunctionExpression, CallExpression, Expression, FunctionExpression, Literal, MemberExpression, Statement } from 'estree';
 import * as path from 'path';
+import { extractModuleSpecifier } from '../utils/ExtractUtils';
 import { findVariableFromScope } from '../utils/ScopeUtils';
 
 const isKatamariFunModule = (filePath: string): boolean => {
@@ -22,10 +23,7 @@ const isKatamariFunConstant = (context: Rule.RuleContext, node: MemberExpression
       const def = funVar.defs[0];
       const parent = def.parent;
       if (def.type === 'ImportBinding' && parent?.type === 'ImportDeclaration') {
-        const parentSource = parent.source;
-        if (parentSource.type === 'Literal' && parentSource.raw?.includes('katamari')) {
-          return true;
-        }
+        return extractModuleSpecifier(parent).includes('katamari');
       }
     }
   }

--- a/src/main/ts/utils/ScopeUtils.ts
+++ b/src/main/ts/utils/ScopeUtils.ts
@@ -1,6 +1,5 @@
 import { Rule, Scope } from 'eslint';
 import { exists } from './Arr';
-import Variable = Scope.Variable;
 
 export const hasVariableInScope = (context: Rule.RuleContext, name: string) => {
   let scope: Scope.Scope | null = context.getScope();
@@ -13,7 +12,7 @@ export const hasVariableInScope = (context: Rule.RuleContext, name: string) => {
   return false;
 };
 
-export const findVariableFromScope = (context: Rule.RuleContext, name: string): Variable | undefined => {
+export const findVariableFromScope = (context: Rule.RuleContext, name: string): Scope.Variable | undefined => {
   let scope: Scope.Scope | null = context.getScope();
   while (scope && scope.type !== 'global') {
     const foundVar = scope.variables.find((v) => v.name === name);

--- a/src/main/ts/utils/ScopeUtils.ts
+++ b/src/main/ts/utils/ScopeUtils.ts
@@ -1,5 +1,6 @@
 import { Rule, Scope } from 'eslint';
 import { exists } from './Arr';
+import Variable = Scope.Variable;
 
 export const hasVariableInScope = (context: Rule.RuleContext, name: string) => {
   let scope: Scope.Scope | null = context.getScope();
@@ -10,4 +11,16 @@ export const hasVariableInScope = (context: Rule.RuleContext, name: string) => {
     scope = scope.upper;
   }
   return false;
+};
+
+export const findVariableFromScope = (context: Rule.RuleContext, name: string): Variable | undefined => {
+  let scope: Scope.Scope | null = context.getScope();
+  while (scope && scope.type !== 'global') {
+    const foundVar = scope.variables.find((v) => v.name === name);
+    if (foundVar !== undefined) {
+      return foundVar;
+    }
+    scope = scope.upper;
+  }
+  return undefined;
 };

--- a/src/test/rules/PreferFunTest.ts
+++ b/src/test/rules/PreferFunTest.ts
@@ -59,11 +59,14 @@ ruleTester.run('prefer-fun', preferFun, {
     },
     {
       code: `
+      import { Fun } from '@ephox/katamari';
       const e = () => true;
       const f = function () { return true; };
       const g = { a: function () { return true; } };
+      const h = Fun.constant(true);
       `,
       errors: [
+        { message: 'Use `Fun.always` instead of redeclaring a function that always returns true, eg: `() => true`' },
         { message: 'Use `Fun.always` instead of redeclaring a function that always returns true, eg: `() => true`' },
         { message: 'Use `Fun.always` instead of redeclaring a function that always returns true, eg: `() => true`' },
         { message: 'Use `Fun.always` instead of redeclaring a function that always returns true, eg: `() => true`' }
@@ -71,11 +74,14 @@ ruleTester.run('prefer-fun', preferFun, {
     },
     {
       code: `
-      const h = () => false;
-      const i = function () { return false; };
-      const j = { a: () => false };
+      import { Fun } from '@ephox/katamari';
+      const i = () => false;
+      const j = function () { return false; };
+      const k = { a: () => false };
+      const l = Fun.constant(false);
       `,
       errors: [
+        { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' },
         { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' },
         { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' },
         { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' }


### PR DESCRIPTION
I noticed when doing limbo that the linter was allowing `if (condition) { expression }`, which we normally don't allow. So I've added the `brace-style` rule to fix that.

I've also fixed an issue @ashfordneil found whereby `Fun.constant(true)` wasn't being flagged as something to be replaced by `Fun.always`.