### PR TITLE
Enforce newlines between import groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.9.0 - 2021-06-14
+
+### Changed
+- The editor configuration now enforces newlines between import groups.
+
 ## 1.8.0 - 2021-05-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.js",

--- a/src/main/ts/configs/Editor.ts
+++ b/src/main/ts/configs/Editor.ts
@@ -20,8 +20,13 @@ export const editor: Linter.Config = {
     }],
     'arrow-body-style': 'off', // Disabled as it causes readability issues in more complex cases
     'import/order': [ 'error', {
-      groups: [ 'builtin', 'external', 'internal', 'parent', 'sibling', 'index' ],
-      alphabetize: {
+      'newlines-between': 'always',
+      'groups': [
+        [ 'builtin', 'external' ],
+        'internal',
+        [ 'parent', 'sibling', 'index' ]
+      ],
+      'alphabetize': {
         order: 'asc',
         caseInsensitive: true
       }


### PR DESCRIPTION
As discussed in slack today, this makes it so the import groups have a newline between them only for the editor configuration, not the standard configuration.