### PR TITLE
TINY-7588: Enable newlines between imports and flag more Main imports as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.9.0 - 2021-06-14
 
+### Added
+- The `@tinymce/prefer-fun` rule now supports configuring which rules should be checked.
+
 ### Improved
 - The `@tinymce/no-main-module-imports` rule now detects Main imports via aliases from outside the `src/main/` directory.
+- The `@tinymce/prefer-fun` rule now detects where `Fun.constant` should be used.
 
 ### Changed
 - The editor configuration now enforces newlines between import groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Improved
 - The `@tinymce/no-main-module-imports` rule now detects Main imports via aliases from outside the `src/main/` directory.
-- The `@tinymce/prefer-fun` rule now detects where `Fun.constant` should be used.
+- The `@tinymce/prefer-fun` rule now detects where `Fun.constant` and `Fun.identity` should be used.
 
 ### Changed
 - The editor configuration now enforces newlines between import groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.9.0 - 2021-06-14
 
+### Improved
+- The `@tinymce/no-main-module-imports` rule now detects Main imports via aliases from outside the `src/main/` directory.
+
 ### Changed
 - The editor configuration now enforces newlines between import groups.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## 1.9.0 - 2021-06-14
+## 1.9.0 - 2021-06-17
 
 ### Added
 - The `@tinymce/prefer-fun` rule now supports configuring which rules should be checked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 1.9.0 - 2021-06-14
+
+### Changed
+- The editor configuration now enforces newlines between import groups.
+
 ## 1.8.0 - 2021-05-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.js",

--- a/src/main/ts/configs/Editor.ts
+++ b/src/main/ts/configs/Editor.ts
@@ -20,8 +20,13 @@ export const editor: Linter.Config = {
     }],
     'arrow-body-style': 'off', // Disabled as it causes readability issues in more complex cases
     'import/order': [ 'error', {
-      groups: [ 'builtin', 'external', 'internal', 'parent', 'sibling', 'index' ],
-      alphabetize: {
+      'newlines-between': 'always',
+      'groups': [
+        [ 'builtin', 'external' ],
+        'internal',
+        [ 'parent', 'sibling', 'index' ]
+      ],
+      'alphabetize': {
         order: 'asc',
         caseInsensitive: true
       }

--- a/src/main/ts/rules/PreferFun.ts
+++ b/src/main/ts/rules/PreferFun.ts
@@ -1,8 +1,20 @@
+import { TSESTree } from '@typescript-eslint/typescript-estree';
 import { Rule } from 'eslint';
-import { ArrowFunctionExpression, CallExpression, Expression, FunctionExpression, Literal, MemberExpression, Statement } from 'estree';
+import {
+  ArrowFunctionExpression, CallExpression, Expression, FunctionExpression, Literal, MemberExpression, RegExpLiteral, SpreadElement, Statement
+} from 'estree';
 import * as path from 'path';
 import { extractModuleSpecifier } from '../utils/ExtractUtils';
-import { findVariableFromScope } from '../utils/ScopeUtils';
+import { findVariableFromScope, isConstantVariable, isVarUsedBeforeDeclaration } from '../utils/ScopeUtils';
+
+type FuncExpression = ArrowFunctionExpression | FunctionExpression;
+
+const enum Option {
+  Noop = 'Noop',
+  Never = 'Never',
+  Always = 'Always',
+  Constant = 'Constant'
+}
 
 const isKatamariFunModule = (filePath: string): boolean => {
   const pathWithoutExt = filePath.replace(/\.[tj]s$/, '');
@@ -31,6 +43,48 @@ const isKatamariFunConstant = (context: Rule.RuleContext, node: MemberExpression
   return false;
 };
 
+const isRegExpLiteral = (literal: Literal): literal is RegExpLiteral =>
+  Object.prototype.hasOwnProperty.call(literal, 'regex');
+
+const isBooleanLiteral = (expr: Expression | SpreadElement): expr is Literal => {
+  if (expr.type === 'Literal') {
+    return expr.raw === 'false' || expr.raw === 'true';
+  } else {
+    return false;
+  }
+};
+
+const isFunctionExpression = (expr: Expression): expr is FunctionExpression =>
+  expr.type === 'FunctionExpression' || expr.type === 'ArrowFunctionExpression';
+
+const isConstant = (context: Rule.RuleContext, func: FuncExpression, obj: Expression): boolean => {
+  if (hasTypeParameters(func)) {
+    // If the function has type generics then treat it as not being constant
+    return false;
+  } else if (obj.type === 'Literal') {
+    // Regexes can maintain state, so they aren't considered a constant
+    return !isRegExpLiteral(obj);
+  } else if (obj.type === 'TemplateLiteral') {
+    // If a template does variable replacement, then it's not a constant
+    return obj.expressions.length === 0;
+  } else if (obj.type === 'Identifier') {
+    const variable = findVariableFromScope(context, obj.name);
+    return variable !== undefined && isConstantVariable(variable) && !isVarUsedBeforeDeclaration(obj, variable);
+  } else {
+    return false;
+  }
+};
+
+const hasTypeParameters = (func: CallExpression | FunctionExpression | ArrowFunctionExpression): boolean => {
+  const tsFunc = func as TSESTree.CallExpression | TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
+  const params = tsFunc.typeParameters;
+  if (params !== undefined && params.type === 'TSTypeParameterDeclaration') {
+    return params.params.length > 0;
+  } else {
+    return false;
+  }
+};
+
 export const preferFun: Rule.RuleModule = {
   meta: {
     type: 'suggestion',
@@ -40,46 +94,60 @@ export const preferFun: Rule.RuleModule = {
     messages: {
       preferNoop: 'Use `Fun.noop` instead of redeclaring a no-op function, eg: `() => {}`',
       preferAlways: 'Use `Fun.always` instead of redeclaring a function that always returns true, eg: `() => true`',
-      preferNever: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`'
-    }
+      preferNever: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`',
+      preferConstant: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          noop: { type: 'boolean' },
+          always: { type: 'boolean' },
+          never: { type: 'boolean' },
+          constant: { type: 'boolean' }
+        },
+        additionalProperties: false
+      }
+    ]
   },
   create: (context) => {
-    const reportIfRequired = (func: CallExpression | FunctionExpression | ArrowFunctionExpression, literal: Literal | null) => {
-      if (literal === null) {
+    const options = context.options[0] || {};
+
+    const report = (func: CallExpression | FuncExpression, type: Option) => {
+      if (options[type.toLowerCase()] !== false) {
         context.report({
           node: func,
-          messageId: 'preferNoop'
-        });
-      } else if (literal.raw === 'true') {
-        context.report({
-          node: func,
-          messageId: 'preferAlways'
-        });
-      } else if (literal.raw === 'false') {
-        context.report({
-          node: func,
-          messageId: 'preferNever'
+          messageId: `prefer${type}`
         });
       }
     };
 
-    const validateFunctionBody = (func: FunctionExpression | ArrowFunctionExpression, body: Statement | Expression) => {
-      if (body.type === 'BlockStatement') {
+    const reportIfRequired = (func: CallExpression | FuncExpression, expr: Expression | null) => {
+      if (expr === null) {
+        report(func, Option.Noop);
+      } else if (isBooleanLiteral(expr)) {
+        report(func, expr.raw === 'true' ? Option.Always : Option.Never);
+      } else if (isFunctionExpression(func)) {
+        // We're dealing with an identifier, primitive value, regex or similar here
+        // so we potentially should be using Fun.constant()
+        if (isConstant(context, func, expr)) {
+          report(func, Option.Constant);
+        }
+      }
+    };
+
+    const validateFunctionBody = (func: FuncExpression, body: Statement | Expression | null) => {
+      if (body === null || body.type === 'Literal' || body.type === 'Identifier' || body.type === 'TemplateLiteral') {
+        reportIfRequired(func, body);
+      } else if (body.type === 'BlockStatement') {
         const funcBody = body.body;
         if (funcBody.length === 1) {
           validateFunctionBody(func, funcBody[0]);
         } else if (funcBody.length === 0) {
-          context.report({
-            node: func,
-            messageId: 'preferNoop'
-          });
+          report(func, Option.Noop);
         }
-      } else if (body.type === 'ReturnStatement') {
-        if (body.argument === null || body.argument?.type === 'Literal') {
-          reportIfRequired(func, body.argument);
-        }
-      } else if (body.type === 'Literal') {
-        reportIfRequired(func, body);
+      } else if (body.type === 'ReturnStatement' && body.argument !== undefined) {
+        validateFunctionBody(func, body.argument);
       }
     };
 
@@ -103,7 +171,8 @@ export const preferFun: Rule.RuleModule = {
             const callee = node.callee;
             if (callee.type === 'MemberExpression' && node.arguments.length === 1 && isKatamariFunConstant(context, callee)) {
               const arg = node.arguments[0];
-              if (arg.type === 'Literal') {
+              // We only care about Fun.constant(false) or Fun.constant(true) here
+              if (isBooleanLiteral(arg)) {
                 reportIfRequired(node, arg);
               }
             }

--- a/src/main/ts/utils/NewOrCallUtils.ts
+++ b/src/main/ts/utils/NewOrCallUtils.ts
@@ -32,5 +32,5 @@ export const forIdentifier = (f: (node: CallExpression | NewExpression | Identif
         checkArguments(node);
       }
     }
-  }
+  };
 };

--- a/src/main/ts/utils/ScopeUtils.ts
+++ b/src/main/ts/utils/ScopeUtils.ts
@@ -1,16 +1,5 @@
 import { Rule, Scope } from 'eslint';
-import { exists } from './Arr';
-
-export const hasVariableInScope = (context: Rule.RuleContext, name: string) => {
-  let scope: Scope.Scope | null = context.getScope();
-  while (scope && scope.type !== 'global') {
-    if (exists(scope.variables, (v) => v.name === name)) {
-      return true;
-    }
-    scope = scope.upper;
-  }
-  return false;
-};
+import { Identifier } from 'estree';
 
 export const findVariableFromScope = (context: Rule.RuleContext, name: string): Scope.Variable | undefined => {
   let scope: Scope.Scope | null = context.getScope();
@@ -22,4 +11,27 @@ export const findVariableFromScope = (context: Rule.RuleContext, name: string): 
     scope = scope.upper;
   }
   return undefined;
+};
+
+export const hasVariableInScope = (context: Rule.RuleContext, name: string) =>
+  findVariableFromScope(context, name) !== undefined;
+
+export const isConstantVariable = (variable: Scope.Variable) => {
+  const def = variable.defs[0];
+  if (def !== undefined && def.parent?.type === 'VariableDeclaration') {
+    return def.parent.kind === 'const';
+  } else {
+    return false;
+  }
+};
+
+export const isVarUsedBeforeDeclaration = (identifier: Identifier, definition: Scope.Variable) => {
+  const definitionLoc = definition.identifiers[0]?.loc?.start;
+  const currentLoc = identifier.loc?.start;
+  if (definitionLoc !== undefined && currentLoc !== undefined) {
+    return definitionLoc.line >= currentLoc.line;
+  } else {
+    // We don't know the location, so just assume the identifier is used before the variable declaration
+    return true;
+  }
 };

--- a/src/test/rules/NoMainModuleImportsTest.ts
+++ b/src/test/rules/NoMainModuleImportsTest.ts
@@ -43,6 +43,16 @@ ruleTester.run('no-main-module-imports', noMainModuleImports, {
       code: 'import { B } from \'../api/Main\';',
       filename: 'src/main/ts/core/File.ts',
       errors: [{ message: 'Direct import to Main module is forbidden.' }]
+    },
+    {
+      code: 'import { A } from \'ephox/swag/api/Main\';',
+      filename: 'src/test/ts/File.ts',
+      errors: [{ message: 'Direct import to Main module is forbidden.' }]
+    },
+    {
+      code: 'import { A } from \'ephox/swag/api/Main\';',
+      filename: 'src/demo/ts/Demo.ts',
+      errors: [{ message: 'Direct import to Main module is forbidden.' }]
     }
   ]
 });

--- a/src/test/rules/PreferFunTest.ts
+++ b/src/test/rules/PreferFunTest.ts
@@ -28,9 +28,9 @@ ruleTester.run('prefer-fun', preferFun, {
     },
     {
       code: `
-      const d = () => 'some string';
-      const e = { a: () => d };
-      const f = function () { return 6; };
+      const d = Fun.constant('some string');
+      const e = { a: Fun.constant(d) };
+      const f = Fun.constant(6);
       `
     },
     {
@@ -39,6 +39,22 @@ ruleTester.run('prefer-fun', preferFun, {
       const noop = () => { };
       const never = () => false;
       const always = () => true;
+      `
+    },
+    {
+      code: `
+      let g = 'word';
+      const h = () => g;
+      const i = () => j;
+      const j = { };
+      const k = function() { return /a+/; };
+      const l = () => \`\${g}\`;
+      `
+    },
+    {
+      code: `
+      const m = '';
+      const n = <T>(): Maybe<T> => l;
       `
     }
   ],
@@ -85,6 +101,20 @@ ruleTester.run('prefer-fun', preferFun, {
         { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' },
         { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' },
         { message: 'Use `Fun.never` instead of redeclaring a function that always returns false, eg: `() => false`' }
+      ],
+    },
+    {
+      code: `
+      const m = () => 'some string';
+      const n = { a: () => m };
+      const o = function () { return 6; };
+      const p = () => \`template\`;
+      `,
+      errors: [
+        { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' },
+        { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' },
+        { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' },
+        { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' }
       ],
     }
   ]

--- a/src/test/rules/PreferFunTest.ts
+++ b/src/test/rules/PreferFunTest.ts
@@ -116,6 +116,16 @@ ruleTester.run('prefer-fun', preferFun, {
         { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' },
         { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' }
       ],
+    },
+    {
+      code: `
+      const q = function(x) { return x; };
+      const r = [].map((x) => x);
+      `,
+      errors: [
+        { message: 'Use `Fun.identity` instead of redeclaring a function that always returns the arguments, eg: `(x) => x`' },
+        { message: 'Use `Fun.identity` instead of redeclaring a function that always returns the arguments, eg: `(x) => x`' }
+      ],
     }
   ]
 });


### PR DESCRIPTION
As discussed in slack on Friday, this makes the following changes:
- The import groups require a newline between them only for the editor configuration, not the standard configuration.
- Main imports from outside `src/main/` that are path aliases are now flagged as errors. eg `import { Optionals } from 'ephox/katamari/api/Main';`

- [x] Update changelog date