### PR TITLE
TINY-7588: Improve the `prefer-fun` rule to detect where `Fun.identity` should be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Improved
 - The `@tinymce/no-main-module-imports` rule now detects Main imports via aliases from outside the `src/main/` directory.
-- The `@tinymce/prefer-fun` rule now detects where `Fun.constant` should be used.
+- The `@tinymce/prefer-fun` rule now detects where `Fun.constant` and `Fun.identity` should be used.
 
 ### Changed
 - The editor configuration now enforces newlines between import groups.

--- a/src/test/rules/PreferFunTest.ts
+++ b/src/test/rules/PreferFunTest.ts
@@ -116,6 +116,16 @@ ruleTester.run('prefer-fun', preferFun, {
         { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' },
         { message: 'Use `Fun.constant` instead of redeclaring a function that always returns the same value, eg: `() => 0`' }
       ],
+    },
+    {
+      code: `
+      const q = function(x) { return x; };
+      const r = [].map((x) => x);
+      `,
+      errors: [
+        { message: 'Use `Fun.identity` instead of redeclaring a function that always returns the arguments, eg: `(x) => x`' },
+        { message: 'Use `Fun.identity` instead of redeclaring a function that always returns the arguments, eg: `(x) => x`' }
+      ],
     }
   ]
 });


### PR DESCRIPTION
This makes the `prefer-fun` rule check for a number of cases where `Fun.identity` should be used instead.