### PR TITLE
Added rule to enforce pascal case type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Enabled the `@typescript-eslint/naming-convention` rule so that it enforces pascal case type names.
+
 ## 2.0.1 - 2021-11-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-
 - Enabled the `@typescript-eslint/naming-convention` rule so that it enforces pascal case type names.
 
 ## 2.0.1 - 2021-11-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
 - Enabled the `@typescript-eslint/naming-convention` rule so that it enforces pascal case type names.
 
 ## 2.0.1 - 2021-11-25

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "2.0.2-rc",
+  "version": "2.1.0-rc",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.js",

--- a/src/main/ts/configs/Standard.ts
+++ b/src/main/ts/configs/Standard.ts
@@ -33,6 +33,13 @@ export const base: Linter.Config = {
       singleline: { delimiter: 'semi', requireLast: false }
     }],
     '@typescript-eslint/member-ordering': 'error',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'typeLike',
+        format: [ 'PascalCase' ]
+      }
+    ],
     '@typescript-eslint/no-duplicate-imports': 'error',
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-for-in-array': 'error',


### PR DESCRIPTION
Related Ticket: 

Description of Changes:
* This makes sure that `type fooBar` needs to be `type FooBar` wasn't sure if other rules should be added to it maybe we do that as we find things.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Review comments resolved
