### PR TITLE
TINY-9086: Fixed some rules failing to detect issues properly on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 2.2.1 - 2022-08-30
+
+### Fixed
+- Some rules did not work correctly on Windows.
+
 ## 2.2.0 - 2022-08-25
 
 ### Added

--- a/src/main/ts/rules/NoDirectEditorEvents.ts
+++ b/src/main/ts/rules/NoDirectEditorEvents.ts
@@ -17,7 +17,7 @@ export const noDirectEditorEvents: Rule.RuleModule = {
     const filename = context.getFilename();
     // Ignore in tests, demos or Events.ts
     // NOTE: To allow for some legacy setups we currently only enforce `Events.ts` instead of `api/Events.ts`
-    if (isPathInTest(filename) || isPathInDemo(filename) || filename.endsWith('/Events.ts')) {
+    if (isPathInTest(filename) || isPathInDemo(filename) || filename.match(/[\/\\]Events\.ts$/)) {
       return {};
     } else {
       return {

--- a/src/main/ts/rules/NoDirectEditorEvents.ts
+++ b/src/main/ts/rules/NoDirectEditorEvents.ts
@@ -1,7 +1,7 @@
 import { Rule } from 'eslint';
 import { isEditorMemberExpression } from '../utils/EditorUtils';
 import { extractMemberIdentifiers } from '../utils/ExtractUtils';
-import { isPathInDemo, isPathInTest } from '../utils/PathUtils';
+import { isPathInDemo, isPathInTest, normalizeFilePath } from '../utils/PathUtils';
 
 export const noDirectEditorEvents: Rule.RuleModule = {
   meta: {
@@ -14,10 +14,10 @@ export const noDirectEditorEvents: Rule.RuleModule = {
     }
   },
   create: (context) => {
-    const filename = context.getFilename();
+    const filename = normalizeFilePath(context.getFilename());
     // Ignore in tests, demos or Events.ts
     // NOTE: To allow for some legacy setups we currently only enforce `Events.ts` instead of `api/Events.ts`
-    if (isPathInTest(filename) || isPathInDemo(filename) || filename.match(/[\/\\]Events\.ts$/)) {
+    if (isPathInTest(filename) || isPathInDemo(filename) || filename.endsWith('/Events.ts')) {
       return {};
     } else {
       return {

--- a/src/main/ts/rules/NoDirectEditorOptions.ts
+++ b/src/main/ts/rules/NoDirectEditorOptions.ts
@@ -18,7 +18,7 @@ export const noDirectEditorOptions: Rule.RuleModule = {
     const filename = context.getFilename();
     // Ignore in tests, demos or Options.ts
     // NOTE: To allow for some legacy setups we currently only enforce `Options.ts` instead of `api/Options.ts`
-    if (isPathInTest(filename) || isPathInDemo(filename) || filename.endsWith('/Options.ts')) {
+    if (isPathInTest(filename) || isPathInDemo(filename) || filename.match(/[\/\\]Options\.ts$/)) {
       return {};
     } else {
       return {

--- a/src/main/ts/rules/NoDirectEditorOptions.ts
+++ b/src/main/ts/rules/NoDirectEditorOptions.ts
@@ -1,7 +1,7 @@
 import { Rule } from 'eslint';
 import { isEditorMemberExpression } from '../utils/EditorUtils';
 import { extractMemberIdentifiers } from '../utils/ExtractUtils';
-import { isPathInDemo, isPathInTest } from '../utils/PathUtils';
+import { isPathInDemo, isPathInTest, normalizeFilePath } from '../utils/PathUtils';
 
 export const noDirectEditorOptions: Rule.RuleModule = {
   meta: {
@@ -15,10 +15,10 @@ export const noDirectEditorOptions: Rule.RuleModule = {
     }
   },
   create: (context) => {
-    const filename = context.getFilename();
+    const filename = normalizeFilePath(context.getFilename());
     // Ignore in tests, demos or Options.ts
     // NOTE: To allow for some legacy setups we currently only enforce `Options.ts` instead of `api/Options.ts`
-    if (isPathInTest(filename) || isPathInDemo(filename) || filename.match(/[\/\\]Options\.ts$/)) {
+    if (isPathInTest(filename) || isPathInDemo(filename) || filename.endsWith('/Options.ts')) {
       return {};
     } else {
       return {

--- a/src/main/ts/rules/NoMainModuleImports.ts
+++ b/src/main/ts/rules/NoMainModuleImports.ts
@@ -1,6 +1,6 @@
 import { Rule } from 'eslint';
 import { isInternalPathAlias, isMainImport } from '../utils/ImportUtils';
-import { isPathInMain } from '../utils/PathUtils';
+import { isPathInMain, normalizeFilePath } from '../utils/PathUtils';
 import { extractModuleSpecifier } from '../utils/ExtractUtils';
 
 const mainPathValidator = isMainImport;
@@ -18,7 +18,7 @@ export const noMainModuleImports: Rule.RuleModule = {
     }
   },
   create: (context) => {
-    const filename = context.getFilename();
+    const filename = normalizeFilePath(context.getFilename());
     const validator = isPathInMain(filename) ? mainPathValidator : genericPathValidator;
     return {
       ImportDeclaration: (node) => {

--- a/src/main/ts/rules/NoPublicApiModuleImports.ts
+++ b/src/main/ts/rules/NoPublicApiModuleImports.ts
@@ -1,6 +1,6 @@
 import { Rule } from 'eslint';
 import { isInternalPathAlias, isPublicApiImport } from '../utils/ImportUtils';
-import { isPathInDemo, isPathInMain } from '../utils/PathUtils';
+import { isPathInDemo, isPathInMain, normalizeFilePath } from '../utils/PathUtils';
 import { extractModuleSpecifier } from '../utils/ExtractUtils';
 
 const mainPathValidator = isPublicApiImport;
@@ -18,7 +18,7 @@ export const noPublicApiModuleImports: Rule.RuleModule = {
     }
   },
   create: (context) => {
-    const filename = context.getFilename();
+    const filename = normalizeFilePath(context.getFilename());
     // Demo files are the sole location we want to allow
     if (isPathInDemo(filename)) {
       return {};

--- a/src/main/ts/utils/PathUtils.ts
+++ b/src/main/ts/utils/PathUtils.ts
@@ -1,18 +1,12 @@
 // Replace `\` with `/` to handle Windows paths
-const normalizeFilePath = (filePath: string) =>
+export const normalizeFilePath = (filePath: string) =>
   filePath.replace(/\\/g, '/');
 
-export const isPathInMain = (filePath: string) => {
-  const normalizedPath = normalizeFilePath(filePath);
-  return normalizedPath.startsWith('src/main/') || normalizedPath.includes('/src/main/') || normalizedPath.includes('/src/core/main/');
-};
+export const isPathInMain = (normalizedFilePath: string) =>
+  normalizedFilePath.startsWith('src/main/') || normalizedFilePath.includes('/src/main/') || normalizedFilePath.includes('/src/core/main/');
 
-export const isPathInTest = (filePath: string) => {
-  const normalizedPath = normalizeFilePath(filePath);
-  return normalizedPath.startsWith('src/test/') || normalizedPath.includes('/src/test/') || (/src\/[\w\/]+\/test\//).test(normalizedPath);
-};
+export const isPathInTest = (normalizedFilePath: string) =>
+  normalizedFilePath.startsWith('src/test/') || normalizedFilePath.includes('/src/test/') || (/src\/[\w\/]+\/test\//).test(normalizedFilePath);
 
-export const isPathInDemo = (filePath: string) => {
-  const normalizedPath = normalizeFilePath(filePath);
-  return normalizedPath.startsWith('src/demo/') || normalizedPath.includes('/src/demo/') || (/src\/[\w\/]+\/demo\//).test(normalizedPath);
-};
+export const isPathInDemo = (normalizedFilePath: string) =>
+  normalizedFilePath.startsWith('src/demo/') || normalizedFilePath.includes('/src/demo/') || (/src\/[\w\/]+\/demo\//).test(normalizedFilePath);

--- a/src/main/ts/utils/PathUtils.ts
+++ b/src/main/ts/utils/PathUtils.ts
@@ -1,8 +1,18 @@
-export const isPathInMain = (filePath: string) =>
-  filePath.startsWith('src/main/') || filePath.includes('/src/main/') || filePath.includes('/src/core/main/');
+// Replace `\` with `/` to handle Windows paths
+const normalizeFilePath = (filePath: string) =>
+  filePath.replace(/\\/g, '/');
 
-export const isPathInTest = (filePath: string) =>
-  filePath.startsWith('src/test/') || filePath.includes('/src/test/') || (/src\/[\w\/]+\/test\//).test(filePath);
+export const isPathInMain = (filePath: string) => {
+  const normalizedPath = normalizeFilePath(filePath);
+  return normalizedPath.startsWith('src/main/') || normalizedPath.includes('/src/main/') || normalizedPath.includes('/src/core/main/');
+};
 
-export const isPathInDemo = (filePath: string) =>
-  filePath.startsWith('src/demo/') || filePath.includes('/src/demo/') || (/src\/[\w\/]+\/demo\//).test(filePath);
+export const isPathInTest = (filePath: string) => {
+  const normalizedPath = normalizeFilePath(filePath);
+  return normalizedPath.startsWith('src/test/') || normalizedPath.includes('/src/test/') || (/src\/[\w\/]+\/test\//).test(normalizedPath);
+};
+
+export const isPathInDemo = (filePath: string) => {
+  const normalizedPath = normalizeFilePath(filePath);
+  return normalizedPath.startsWith('src/demo/') || normalizedPath.includes('/src/demo/') || (/src\/[\w\/]+\/demo\//).test(normalizedPath);
+};

--- a/src/test/rules/NoDirectEditorEventsTest.ts
+++ b/src/test/rules/NoDirectEditorEventsTest.ts
@@ -16,11 +16,6 @@ ruleTester.run('no-direct-editor-events', noDirectEditorEvents, {
       editor.fire('myevent', { value: 'custom' });
       `
     },
-    // Legacy case
-    {
-      filename: 'src/main/ts/alien/Events.ts',
-      code: 'editor.dispatch(\'mytestevent\', { value: \'test\' });'
-    },
     {
       filename: 'src/test/ts/MyTest.ts',
       code: 'editor.dispatch(\'mytestevent\', { value: \'test\' });'
@@ -28,12 +23,44 @@ ruleTester.run('no-direct-editor-events', noDirectEditorEvents, {
     {
       filename: 'src/demo/ts/Demo.ts',
       code: 'editor.dispatch(\'mydemoevent\');'
+    },
+    // Windows filepath
+    {
+      filename: 'src\\main\\ts\\api\\Events.ts',
+      code: `
+      editor.dispatch('myevent', { value: 'custom' });
+      editor.dispatch('nodata');
+      editor.fire('myevent', { value: 'custom' });
+      `
+    },
+    // Legacy case
+    {
+      filename: 'src/main/ts/alien/Events.ts',
+      code: 'editor.dispatch(\'mytestevent\', { value: \'test\' });'
+    },
+    {
+      filename: 'src\\main\\ts\\alien\\Events.ts',
+      code: 'editor.dispatch(\'mytestevent\', { value: \'test\' });'
     }
   ],
 
   invalid: [
     {
       filename: 'src/main/ts/Plugin.ts',
+      code: `
+      editor.dispatch('myevent', { value: 'custom' });
+      editor.dispatch('nodata');
+      editor.fire('myevent', { value: 'custom' });
+      `,
+      errors: [
+        { message: 'Dispatching events is forbidden outside api/Events.ts.' },
+        { message: 'Dispatching events is forbidden outside api/Events.ts.' },
+        { message: 'Dispatching events is forbidden outside api/Events.ts.' }
+      ]
+    },
+    // Windows filepath
+    {
+      filename: 'src\\main\\ts\\Plugin.ts',
       code: `
       editor.dispatch('myevent', { value: 'custom' });
       editor.dispatch('nodata');

--- a/src/test/rules/NoDirectEditorOptionsTest.ts
+++ b/src/test/rules/NoDirectEditorOptionsTest.ts
@@ -16,17 +16,30 @@ ruleTester.run('no-direct-editor-options', noDirectEditorOptions, {
       editor.getParam('my_option');
       `
     },
-    // Legacy case
-    {
-      filename: 'src/main/ts/color/Options.ts',
-      code: 'editor.options.get("my_option");'
-    },
     {
       filename: 'src/test/ts/MyTest.ts',
       code: 'editor.options.get("my_option");'
     },
     {
       filename: 'src/demo/ts/Demo.ts',
+      code: 'editor.options.get("my_option");'
+    },
+    // Windows filepath
+    {
+      filename: 'src\\main\\ts\\api\\Options.ts',
+      code: `
+      editor.options.register('my_option', { processor: 'string', default: 'test' });
+      editor.options.get('my_option');
+      editor.getParam('my_option');
+      `
+    },
+    // Legacy case
+    {
+      filename: 'src/main/ts/color/Options.ts',
+      code: 'editor.options.get("my_option");'
+    },
+    {
+      filename: 'src\\main\\ts\\color\\Options.ts',
       code: 'editor.options.get("my_option");'
     }
   ],
@@ -45,6 +58,23 @@ ruleTester.run('no-direct-editor-options', noDirectEditorOptions, {
     },
     {
       filename: 'src/main/ts/Plugin.ts',
+      code: 'editor.options.register("my_option", { processor: \'string\', default: \'test\' });',
+      errors: [{ message: 'Registering options is forbidden outside api/Options.ts.' }]
+    },
+    // Windows filepath
+    {
+      filename: 'src\\main\\ts\\core\\Actions.ts',
+      code: `
+      editor.options.get("my_option");
+      editor.getParam("my_option");
+      `,
+      errors: [
+        { message: 'Direct access to options is forbidden outside api/Options.ts.' },
+        { message: 'Direct access to options is forbidden outside api/Options.ts.' }
+      ]
+    },
+    {
+      filename: 'src\\main\\ts\\Plugin.ts',
       code: 'editor.options.register("my_option", { processor: \'string\', default: \'test\' });',
       errors: [{ message: 'Registering options is forbidden outside api/Options.ts.' }]
     }

--- a/src/test/rules/NoMainModuleImportsTest.ts
+++ b/src/test/rules/NoMainModuleImportsTest.ts
@@ -31,6 +31,15 @@ ruleTester.run('no-main-module-imports', noMainModuleImports, {
     {
       code: 'import { B } from \'../api/SomethingNotMain\';',
       filename: 'src/main/ts/core/File.ts',
+    },
+    // Windows filepaths
+    {
+      code: 'import { A } from \'./SomethingNotMain\';',
+      filename: 'src\\main\\ts\\api\\File.ts',
+    },
+    {
+      code: 'import { B } from \'../api/SomethingNotMain\';',
+      filename: 'src\\main\\ts\\core\\File.ts',
     }
   ],
   invalid: [
@@ -52,6 +61,17 @@ ruleTester.run('no-main-module-imports', noMainModuleImports, {
     {
       code: 'import { A } from \'ephox/swag/api/Main\';',
       filename: 'src/demo/ts/Demo.ts',
+      errors: [{ message: 'Direct import to Main module is forbidden.' }]
+    },
+    // Windows filepaths
+    {
+      code: 'import { A } from \'./Main\';',
+      filename: 'src\\main\\ts\\api\\File.ts',
+      errors: [{ message: 'Direct import to Main module is forbidden.' }]
+    },
+    {
+      code: 'import { B } from \'../api/Main\';',
+      filename: 'src\\main\\ts\\core\\File.ts',
       errors: [{ message: 'Direct import to Main module is forbidden.' }]
     }
   ]


### PR DESCRIPTION
Related Ticket: TINY-9086

Description of Changes:
* Fixed a number of rules not working expected when run on Windows

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)
