### PR TITLE
TINY-10602: Disable require-await rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+- Disabled `@typescript-eslint/require-await`, which caused some builds to fail inconsistently and doesn't seem particularly valuable
+
 ## 2.3.1 - 2023-05-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "2.3.2-rc",
+  "version": "2.4.0-rc",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.js",

--- a/src/main/ts/configs/Standard.ts
+++ b/src/main/ts/configs/Standard.ts
@@ -60,6 +60,7 @@ export const base: Linter.Config = {
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/quotes': [ 'error', 'single', { allowTemplateLiterals: true }],
+    '@typescript-eslint/require-await': 'off',
     '@typescript-eslint/restrict-plus-operands': 'off',
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/semi': [ 'error', 'always' ],


### PR DESCRIPTION
Related Ticket: TINY-10602

Description of Changes:
* The require-await rule has been causing problems in the premium CI build, and after doing a bit of research I realised it actually isn't a very useful rule for us. There are times when we just want to return a promise from an `async` function, and that should be fine.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] ~Tests have been added (if applicable)~