### PR TITLE
TINY-11727: Reenable no-floating-promises rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Changed
+- Re-enabled `@typescript-eslint/no-floating-promises` rule
 - Disabled `@typescript-eslint/require-await`, which caused some builds to fail inconsistently and doesn't seem particularly valuable
 
 ## 2.3.1 - 2023-05-21

--- a/src/main/ts/configs/Standard.ts
+++ b/src/main/ts/configs/Standard.ts
@@ -70,13 +70,18 @@ export const base: Linter.Config = {
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/type-annotation-spacing': 'error',
     '@typescript-eslint/unified-signatures': 'error',
+    '@typescript-eslint/no-floating-promises': [
+      'error',
+      {
+        ignoreVoid: false
+      }
+    ],
 
     // TODO: Enable once we no longer support IE 11
     '@typescript-eslint/prefer-includes': 'off',
     '@typescript-eslint/prefer-string-starts-ends-with': 'off',
 
     // TODO: Investigate if these rules should be enabled
-    '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off', // Needs StrictNullChecks
     '@typescript-eslint/no-unnecessary-type-assertion': 'off', // to be investigated, produces different results on a uncompiled environment


### PR DESCRIPTION
Related Ticket: TINY-11727

Description of Changes:
* Turn no-floating-promises rule back on as it is useful to catch potential async issues

Pre-checks:
* [X] Changelog entry added
* [X] package.json version bumped (if first change of new major/minor)
* [X] Tests have been added (if applicable)
