### PR TITLE
TINY-12772: Add new katamari type suggestion rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- Added new `@tinymce/prefer-katamari-type` rule to detect places where the `Type` module from `@ephox/katamari` should be used instead of manual runtime type checks.
+
 ## 3.0.0 - 2025-04-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/eslint-plugin",
-  "version": "3.0.1-rc",
+  "version": "3.1.0-rc",
   "description": "Plugin for ESLint containing Tiny Technologies Inc. standard linting rules",
   "author": "Tiny Technologies Inc.",
   "main": "dist/main/ts/api/Main.mjs",

--- a/src/main/ts/api/Main.mts
+++ b/src/main/ts/api/Main.mts
@@ -9,6 +9,7 @@ import { noMainModuleImports } from '../rules/NoMainModuleImports.js';
 import { noPathAliasImports } from '../rules/NoPathAliasImports.js';
 import { noPublicApiModuleImports } from '../rules/NoPublicApiModuleImports.js';
 import { preferFun } from '../rules/PreferFun.js';
+import { preferType } from '../rules/PreferKatamariType.js';
 import { preferMcAgarTinyAssertions } from '../rules/PreferMcAgarTinyAssertions.js';
 import { preferMcAgarTinyDom } from '../rules/PreferMcAgarTinyDom.js';
 
@@ -24,6 +25,7 @@ const rules = {
   'no-publicapi-module-imports': noPublicApiModuleImports,
   'no-implicit-dom-globals': noImplicitDomGlobals,
   'prefer-fun': preferFun,
+  'prefer-katamari-type': preferType,
   'prefer-mcagar-tiny-assertions': preferMcAgarTinyAssertions,
   'prefer-mcagar-tiny-dom': preferMcAgarTinyDom
 };
@@ -63,6 +65,7 @@ const standard = tseslint.config(
       '@tinymce/no-unimported-promise': 'off',
       '@tinymce/no-implicit-dom-globals': 'error',
       '@tinymce/prefer-fun': 'error',
+      '@tinymce/prefer-katamari-type': 'error',
       '@tinymce/prefer-mcagar-tiny-assertions': 'off',
       '@tinymce/prefer-mcagar-tiny-dom': 'off',
     }

--- a/src/main/ts/rules/PreferKatamariType.ts
+++ b/src/main/ts/rules/PreferKatamariType.ts
@@ -1,0 +1,282 @@
+import { ESLintUtils, TSESTree, TSESLint, AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  () => 'https://github.com/tinymce/eslint-plugin'
+);
+
+export const preferType = createRule({
+  name: 'prefer-katamari-type',
+  defaultOptions: [],
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Suggest using Type utility functions from katamari instead of manual type checks',
+    },
+    fixable: 'code',
+    hasSuggestions: true,
+    schema: [
+      // {
+      //   type: "object",
+      //   properties: {
+      //     importName: {
+      //       type: "string",
+      //       description: "The name to use for Type imports (default: 'Type')"
+      //     },
+      //     modulePath: {
+      //       type: "string",
+      //       description: "The module path for Type imports (default: '@ephox/katamari')"
+      //     }
+      //   },
+      //   additionalProperties: false
+      // }
+    ],
+    messages: {
+      preferTypeString: 'Use Type.isString({{variable}}) instead of typeof {{variable}} === \'string\'',
+      preferTypeNumber: 'Use Type.isNumber({{variable}}) instead of typeof {{variable}} === \'number\'',
+      preferTypeBoolean: 'Use Type.isBoolean({{variable}}) instead of typeof {{variable}} === \'boolean\'',
+      preferTypeFunction: 'Use Type.isFunction({{variable}}) instead of typeof {{variable}} === \'function\'',
+      preferTypeObject: 'Use Type.isObject({{variable}}) instead of typeof {{variable}} === \'object\'',
+      preferTypeNull: 'Use Type.isNull({{variable}}) instead of {{variable}} === null',
+      preferTypeUndefined: 'Use Type.isUndefined({{variable}}) instead of {{variable}} === undefined',
+      preferTypeNullable: 'Use Type.isNullable({{variable}}) instead of {{variable}} == null',
+      preferTypeNonNullable: 'Use Type.isNonNullable({{variable}}) instead of {{variable}} != null',
+      preferTypeNonNullableStrict: 'Use Type.isNonNullable({{variable}}) instead of {{variable}} !== null && {{variable}} !== undefined',
+      negatedPreferTypeString: 'Use !Type.isString({{variable}}) instead of typeof {{variable}} !== \'string\'',
+      negatedPreferTypeNumber: 'Use !Type.isNumber({{variable}}) instead of typeof {{variable}} !== \'number\'',
+      negatedPreferTypeBoolean: 'Use !Type.isBoolean({{variable}}) instead of typeof {{variable}} !== \'boolean\'',
+      negatedPreferTypeFunction: 'Use !Type.isFunction({{variable}}) instead of typeof {{variable}} !== \'function\'',
+      negatedPreferTypeObject: 'Use !Type.isObject({{variable}}) instead of typeof {{variable}} !== \'object\'',
+      negatedPreferTypeNull: 'Use !Type.isNull({{variable}}) instead of {{variable}} !== null',
+      negatedPreferTypeUndefined: 'Use !Type.isUndefined({{variable}}) instead of {{variable}} !== undefined'
+    }
+  },
+  create: (context) => {
+    // const options = context.options[0] || {};
+    // const importName = options.importName || 'Type';
+    // const modulePath = options.modulePath || '@ephox/katamari';
+    const importName = 'Type';
+    const modulePath = '@ephox/katamari';
+    const sourceCode = context.sourceCode;
+
+    /**
+     * Get the variable name from a node (handles complex expressions)
+     */
+    const getVariableName = (node: TSESTree.Node): string => sourceCode.getText(node);
+
+    /**
+     * Check if there's already a Type import in the file
+     */
+    const hasTypeImport = () => {
+      const program = sourceCode.ast;
+      return program.body.some((node) => {
+        if (node.type === AST_NODE_TYPES.ImportDeclaration && node.source.value === modulePath) {
+          return node.specifiers.some((spec) => {
+            if (spec.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+              return spec.local.name === importName;
+            }
+            if (spec.type === AST_NODE_TYPES.ImportSpecifier) {
+              return spec.imported.type === AST_NODE_TYPES.Identifier && spec.imported.name === 'Type' && spec.local.name === importName;
+            }
+            return false;
+          });
+        }
+        return false;
+      });
+    };
+
+    /**
+     * Generate import statement if needed
+     */
+    const generateImportFix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix | null => {
+      if (hasTypeImport()) {
+        return null; // Return null instead of empty array when no fix is needed
+      }
+
+      const program = sourceCode.ast;
+      const imports = program.body.filter((node) => node.type === AST_NODE_TYPES.ImportDeclaration);
+
+      if (imports.length > 0) {
+        // Insert after the last import
+        const lastImport = imports[imports.length - 1];
+        return fixer.insertTextAfter(lastImport, `\nimport { Type } from '${modulePath}';`);
+      } else {
+        // Insert at the beginning of the file
+        return fixer.insertTextBefore(program, `import { Type } from '${modulePath}';\n`);
+      }
+    };
+
+    /**
+     * Create a fix function that replaces the expression and adds import if needed
+     */
+    const createFix = (node: TSESTree.Node, replacement: string) => function* (fixer: TSESLint.RuleFixer): Generator<TSESLint.RuleFix> {
+      yield fixer.replaceText(node, replacement);
+      const importFix = generateImportFix(fixer);
+      if (importFix) {
+        yield importFix;
+      }
+    };
+
+    return {
+      LogicalExpression: (node) => {
+        // foo !== null && foo !== undefined -> Type.isNonNullable(foo)
+        // Handle this with higher priority to avoid conflicts with individual binary expressions
+        if (node.operator === '&&' &&
+          node.left.type === AST_NODE_TYPES.BinaryExpression && node.left.operator === '!==' &&
+          node.right.type === AST_NODE_TYPES.BinaryExpression && node.right.operator === '!==') {
+
+          let variable1; let variable2; let isNullCheck = false; let isUndefinedCheck = false;
+
+          // Check left side: foo !== null
+          if (node.left.right.type === AST_NODE_TYPES.Literal && node.left.right.value === null) {
+            variable1 = getVariableName(node.left.left);
+            isNullCheck = true;
+          } else if (node.left.left.type === AST_NODE_TYPES.Literal && node.left.left.value === null) {
+            variable1 = getVariableName(node.left.right);
+            isNullCheck = true;
+          }
+
+          // Check right side: foo !== undefined
+          if (node.right.right.type === AST_NODE_TYPES.Identifier && node.right.right.name === 'undefined') {
+            variable2 = getVariableName(node.right.left);
+            isUndefinedCheck = true;
+          } else if (node.right.left.type === AST_NODE_TYPES.Identifier && node.right.left.name === 'undefined') {
+            variable2 = getVariableName(node.right.right);
+            isUndefinedCheck = true;
+          }
+
+          // If both checks are on the same variable and cover null and undefined
+          if (isNullCheck && isUndefinedCheck && variable1 === variable2) {
+            context.report({
+              node,
+              messageId: 'preferTypeNonNullableStrict',
+              data: { variable: variable1 },
+              fix: createFix(node, `${importName}.isNonNullable(${variable1})`)
+            });
+            return; // Don't process child binary expressions
+          }
+        }
+      },
+
+      BinaryExpression: (node) => {
+        // Skip if this binary expression is part of a logical expression we've already handled
+        if (node.parent && node.parent.type === AST_NODE_TYPES.LogicalExpression) {
+          const parent = node.parent;
+          if (parent.operator === '&&' &&
+            parent.left.type === AST_NODE_TYPES.BinaryExpression && parent.left.operator === '!==' &&
+            parent.right.type === AST_NODE_TYPES.BinaryExpression && parent.right.operator === '!==') {
+            // Let the LogicalExpression handler deal with this
+            return;
+          }
+        }
+        const { left, operator, right } = node;
+
+        // typeof checks: typeof foo === 'string', typeof foo !== 'string'
+        if (left.type === AST_NODE_TYPES.UnaryExpression && left.operator === 'typeof' &&
+          (operator === '===' || operator === '!==' || operator === '==' || operator === '!=') &&
+          right.type === AST_NODE_TYPES.Literal && typeof right.value === 'string') {
+
+          // Skip complex expressions that are not simple identifiers or member expressions
+          if (left.argument.type !== AST_NODE_TYPES.Identifier && left.argument.type !== AST_NODE_TYPES.MemberExpression) {
+            return;
+          }
+
+          const variable = getVariableName(left.argument);
+          const typeValue = right.value;
+          const isNegated = operator === '!==' || operator === '!=';
+
+          type MessageId = 'preferTypeString' | 'preferTypeNumber' | 'preferTypeBoolean' | 'preferTypeFunction' | 'preferTypeObject' |
+            'negatedPreferTypeString' | 'negatedPreferTypeNumber' | 'negatedPreferTypeBoolean' | 'negatedPreferTypeFunction' | 'negatedPreferTypeObject';
+
+          const typeMap: Record<string, { func: string; messageId: MessageId }> = {
+            string: { func: 'isString', messageId: isNegated ? 'negatedPreferTypeString' : 'preferTypeString' },
+            number: { func: 'isNumber', messageId: isNegated ? 'negatedPreferTypeNumber' : 'preferTypeNumber' },
+            boolean: { func: 'isBoolean', messageId: isNegated ? 'negatedPreferTypeBoolean' : 'preferTypeBoolean' },
+            function: { func: 'isFunction', messageId: isNegated ? 'negatedPreferTypeFunction' : 'preferTypeFunction' },
+            object: { func: 'isObject', messageId: isNegated ? 'negatedPreferTypeObject' : 'preferTypeObject' }
+          };
+
+          if (typeMap[typeValue]) {
+            const { func, messageId } = typeMap[typeValue];
+            const replacement = isNegated ? `!${importName}.${func}(${variable})` : `${importName}.${func}(${variable})`;
+
+            context.report({
+              node,
+              messageId,
+              data: { variable },
+              fix: createFix(node, replacement)
+            });
+          }
+        }
+
+        // null checks: foo === null, foo !== null
+        if (((left.type === AST_NODE_TYPES.Identifier || left.type === AST_NODE_TYPES.MemberExpression) &&
+          right.type === AST_NODE_TYPES.Literal && right.value === null) ||
+          (left.type === AST_NODE_TYPES.Literal && left.value === null &&
+            (right.type === AST_NODE_TYPES.Identifier || right.type === AST_NODE_TYPES.MemberExpression))) {
+
+          const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
+          const isNegated = operator === '!==';
+
+          if (operator === '===' || operator === '!==') {
+            const messageId = isNegated ? 'negatedPreferTypeNull' : 'preferTypeNull';
+            const replacement = isNegated ? `!${importName}.isNull(${variable})` : `${importName}.isNull(${variable})`;
+
+            context.report({
+              node,
+              messageId,
+              data: { variable },
+              fix: createFix(node, replacement)
+            });
+          }
+        }
+
+        // undefined checks: foo === undefined, foo !== undefined
+        if (((left.type === AST_NODE_TYPES.Identifier || left.type === AST_NODE_TYPES.MemberExpression) &&
+          right.type === AST_NODE_TYPES.Identifier && right.name === 'undefined') ||
+          (left.type === AST_NODE_TYPES.Identifier && left.name === 'undefined' &&
+            (right.type === AST_NODE_TYPES.Identifier || right.type === AST_NODE_TYPES.MemberExpression))) {
+
+          const variable = (left.type === AST_NODE_TYPES.Identifier && left.name === 'undefined') ? getVariableName(right) : getVariableName(left);
+          const isNegated = operator === '!==';
+
+          if (operator === '===' || operator === '!==') {
+            const messageId = isNegated ? 'negatedPreferTypeUndefined' : 'preferTypeUndefined';
+            const replacement = isNegated ? `!${importName}.isUndefined(${variable})` : `${importName}.isUndefined(${variable})`;
+
+            context.report({
+              node,
+              messageId,
+              data: { variable },
+              fix: createFix(node, replacement)
+            });
+          }
+        }
+
+        // nullable checks: foo == null, foo != null
+        if (((left.type === AST_NODE_TYPES.Identifier || left.type === AST_NODE_TYPES.MemberExpression) &&
+          right.type === AST_NODE_TYPES.Literal && right.value === null) ||
+          (left.type === AST_NODE_TYPES.Literal && left.value === null &&
+            (right.type === AST_NODE_TYPES.Identifier || right.type === AST_NODE_TYPES.MemberExpression))) {
+
+          const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
+
+          if (operator === '==') {
+            context.report({
+              node,
+              messageId: 'preferTypeNullable',
+              data: { variable },
+              fix: createFix(node, `${importName}.isNullable(${variable})`)
+            });
+          } else if (operator === '!=') {
+            context.report({
+              node,
+              messageId: 'preferTypeNonNullable',
+              data: { variable },
+              fix: createFix(node, `${importName}.isNonNullable(${variable})`)
+            });
+          }
+        }
+      }
+    };
+  }
+});

--- a/src/main/ts/rules/PreferKatamariType.ts
+++ b/src/main/ts/rules/PreferKatamariType.ts
@@ -4,9 +4,41 @@ const createRule = ESLintUtils.RuleCreator(
   () => 'https://github.com/tinymce/eslint-plugin'
 );
 
-export const preferType = createRule({
+interface Options {
+  string?: boolean;
+  number?: boolean;
+  boolean?: boolean;
+  function?: boolean;
+  object?: boolean;
+  null?: boolean;
+  undefined?: boolean;
+  nullable?: boolean;
+  nonNullable?: boolean;
+  nonNullableStrict?: boolean;
+}
+
+/**
+ * Report a violation if the option is enabled
+ */
+type MessageIds = 'preferTypeString' | 'preferTypeNumber' | 'preferTypeBoolean' | 'preferTypeFunction' | 'preferTypeObject' |
+                 'preferTypeNull' | 'preferTypeUndefined' | 'preferTypeNullable' | 'preferTypeNonNullable' | 'preferTypeNonNullableStrict' |
+                 'negatedPreferTypeString' | 'negatedPreferTypeNumber' | 'negatedPreferTypeBoolean' | 'negatedPreferTypeFunction' |
+                 'negatedPreferTypeObject' | 'negatedPreferTypeNull' | 'negatedPreferTypeUndefined';
+
+export const preferType = createRule<[Options], MessageIds>({
   name: 'prefer-katamari-type',
-  defaultOptions: [],
+  defaultOptions: [{
+    string: true,
+    number: true,
+    boolean: true,
+    function: true,
+    object: true,
+    null: false,
+    undefined: false,
+    nullable: true,
+    nonNullable: true,
+    nonNullableStrict: true
+  }],
   meta: {
     type: 'suggestion',
     docs: {
@@ -15,20 +47,22 @@ export const preferType = createRule({
     fixable: 'code',
     hasSuggestions: true,
     schema: [
-      // {
-      //   type: "object",
-      //   properties: {
-      //     importName: {
-      //       type: "string",
-      //       description: "The name to use for Type imports (default: 'Type')"
-      //     },
-      //     modulePath: {
-      //       type: "string",
-      //       description: "The module path for Type imports (default: '@ephox/katamari')"
-      //     }
-      //   },
-      //   additionalProperties: false
-      // }
+      {
+        type: 'object',
+        properties: {
+          string: { type: 'boolean' },
+          number: { type: 'boolean' },
+          boolean: { type: 'boolean' },
+          function: { type: 'boolean' },
+          object: { type: 'boolean' },
+          null: { type: 'boolean' },
+          undefined: { type: 'boolean' },
+          nullable: { type: 'boolean' },
+          nonNullable: { type: 'boolean' },
+          nonNullableStrict: { type: 'boolean' }
+        },
+        additionalProperties: false
+      }
     ],
     messages: {
       preferTypeString: 'Use Type.isString({{variable}}) instead of typeof {{variable}} === \'string\'',
@@ -51,12 +85,33 @@ export const preferType = createRule({
     }
   },
   create: (context) => {
-    // const options = context.options[0] || {};
-    // const importName = options.importName || 'Type';
-    // const modulePath = options.modulePath || '@ephox/katamari';
+    const userOptions = context.options[0] || {};
+    const options = {
+      string: userOptions.string ?? true,
+      number: userOptions.number ?? true,
+      boolean: userOptions.boolean ?? true,
+      function: userOptions.function ?? true,
+      object: userOptions.object ?? true,
+      null: userOptions.null ?? false,
+      undefined: userOptions.undefined ?? false,
+      nullable: userOptions.nullable ?? true,
+      nonNullable: userOptions.nonNullable ?? true,
+      nonNullableStrict: userOptions.nonNullableStrict ?? true
+    };
     const importName = 'Type';
     const modulePath = '@ephox/katamari';
     const sourceCode = context.sourceCode;
+
+    const report = (node: TSESTree.Node, messageId: MessageIds, data: Record<string, string>, optionKey: keyof typeof options, replacement: string) => {
+      if (options[optionKey] === true) {
+        context.report({
+          node,
+          messageId,
+          data,
+          fix: createFix(node, replacement)
+        });
+      }
+    };
 
     /**
      * Get the variable name from a node (handles complex expressions)
@@ -94,6 +149,25 @@ export const preferType = createRule({
 
       const program = sourceCode.ast;
       const imports = program.body.filter((node) => node.type === AST_NODE_TYPES.ImportDeclaration);
+
+      // Check if there's already an import from the same module that we can merge with
+      const existingKatamariImport = imports.find((node) =>
+        node.type === AST_NODE_TYPES.ImportDeclaration &&
+        node.source.value === modulePath
+      );
+
+      if (existingKatamariImport) {
+        // Merge with existing import from the same module
+        const sourceText = sourceCode.getText(existingKatamariImport);
+        const updatedImport = sourceText.replace(
+          /import\s*{\s*([^}]*?)\s*}\s*from/,
+          (_match, existingImports) => {
+            const cleanImports = existingImports.trim();
+            return `import { ${cleanImports}, Type } from`;
+          }
+        );
+        return fixer.replaceText(existingKatamariImport, updatedImport);
+      }
 
       if (imports.length > 0) {
         // Insert after the last import
@@ -145,13 +219,9 @@ export const preferType = createRule({
           }
 
           // If both checks are on the same variable and cover null and undefined
-          if (isNullCheck && isUndefinedCheck && variable1 === variable2) {
-            context.report({
-              node,
-              messageId: 'preferTypeNonNullableStrict',
-              data: { variable: variable1 },
-              fix: createFix(node, `${importName}.isNonNullable(${variable1})`)
-            });
+          if (isNullCheck && isUndefinedCheck && variable1 === variable2 && variable1) {
+            const replacement = `${importName}.isNonNullable(${variable1})`;
+            report(node, 'preferTypeNonNullableStrict', { variable: variable1 }, 'nonNullableStrict', replacement);
             return; // Don't process child binary expressions
           }
         }
@@ -187,24 +257,19 @@ export const preferType = createRule({
           type MessageId = 'preferTypeString' | 'preferTypeNumber' | 'preferTypeBoolean' | 'preferTypeFunction' | 'preferTypeObject' |
             'negatedPreferTypeString' | 'negatedPreferTypeNumber' | 'negatedPreferTypeBoolean' | 'negatedPreferTypeFunction' | 'negatedPreferTypeObject';
 
-          const typeMap: Record<string, { func: string; messageId: MessageId }> = {
-            string: { func: 'isString', messageId: isNegated ? 'negatedPreferTypeString' : 'preferTypeString' },
-            number: { func: 'isNumber', messageId: isNegated ? 'negatedPreferTypeNumber' : 'preferTypeNumber' },
-            boolean: { func: 'isBoolean', messageId: isNegated ? 'negatedPreferTypeBoolean' : 'preferTypeBoolean' },
-            function: { func: 'isFunction', messageId: isNegated ? 'negatedPreferTypeFunction' : 'preferTypeFunction' },
-            object: { func: 'isObject', messageId: isNegated ? 'negatedPreferTypeObject' : 'preferTypeObject' }
+          const typeMap: Record<string, { func: string; messageId: MessageId; optionKey: keyof typeof options }> = {
+            string: { func: 'isString', messageId: isNegated ? 'negatedPreferTypeString' : 'preferTypeString', optionKey: 'string' },
+            number: { func: 'isNumber', messageId: isNegated ? 'negatedPreferTypeNumber' : 'preferTypeNumber', optionKey: 'number' },
+            boolean: { func: 'isBoolean', messageId: isNegated ? 'negatedPreferTypeBoolean' : 'preferTypeBoolean', optionKey: 'boolean' },
+            function: { func: 'isFunction', messageId: isNegated ? 'negatedPreferTypeFunction' : 'preferTypeFunction', optionKey: 'function' },
+            object: { func: 'isObject', messageId: isNegated ? 'negatedPreferTypeObject' : 'preferTypeObject', optionKey: 'object' }
           };
 
           if (typeMap[typeValue]) {
-            const { func, messageId } = typeMap[typeValue];
+            const { func, messageId, optionKey } = typeMap[typeValue];
             const replacement = isNegated ? `!${importName}.${func}(${variable})` : `${importName}.${func}(${variable})`;
 
-            context.report({
-              node,
-              messageId,
-              data: { variable },
-              fix: createFix(node, replacement)
-            });
+            report(node, messageId, { variable }, optionKey, replacement);
           }
         }
 
@@ -221,12 +286,7 @@ export const preferType = createRule({
             const messageId = isNegated ? 'negatedPreferTypeNull' : 'preferTypeNull';
             const replacement = isNegated ? `!${importName}.isNull(${variable})` : `${importName}.isNull(${variable})`;
 
-            context.report({
-              node,
-              messageId,
-              data: { variable },
-              fix: createFix(node, replacement)
-            });
+            report(node, messageId, { variable }, 'null', replacement);
           }
         }
 
@@ -243,12 +303,7 @@ export const preferType = createRule({
             const messageId = isNegated ? 'negatedPreferTypeUndefined' : 'preferTypeUndefined';
             const replacement = isNegated ? `!${importName}.isUndefined(${variable})` : `${importName}.isUndefined(${variable})`;
 
-            context.report({
-              node,
-              messageId,
-              data: { variable },
-              fix: createFix(node, replacement)
-            });
+            report(node, messageId, { variable }, 'undefined', replacement);
           }
         }
 
@@ -261,19 +316,11 @@ export const preferType = createRule({
           const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
 
           if (operator === '==') {
-            context.report({
-              node,
-              messageId: 'preferTypeNullable',
-              data: { variable },
-              fix: createFix(node, `${importName}.isNullable(${variable})`)
-            });
+            const replacement = `${importName}.isNullable(${variable})`;
+            report(node, 'preferTypeNullable', { variable }, 'nullable', replacement);
           } else if (operator === '!=') {
-            context.report({
-              node,
-              messageId: 'preferTypeNonNullable',
-              data: { variable },
-              fix: createFix(node, `${importName}.isNonNullable(${variable})`)
-            });
+            const replacement = `${importName}.isNonNullable(${variable})`;
+            report(node, 'preferTypeNonNullable', { variable }, 'nonNullable', replacement);
           }
         }
       }

--- a/src/main/ts/rules/PreferKatamariType.ts
+++ b/src/main/ts/rules/PreferKatamariType.ts
@@ -32,20 +32,22 @@ interface TypeCheckConfig {
   optionKey: keyof Options;
 }
 
+const DEFAULT_OPTIONS: [Options] = [{
+  string: true,
+  number: true,
+  boolean: true,
+  function: true,
+  object: true,
+  null: true,
+  undefined: true,
+  nullable: true,
+  nonNullable: true,
+  nonNullableStrict: true
+}];
+
 export const preferType = createRule<[Options], MessageIds>({
   name: 'prefer-katamari-type',
-  defaultOptions: [{
-    string: true,
-    number: true,
-    boolean: true,
-    function: true,
-    object: true,
-    null: false,
-    undefined: false,
-    nullable: true,
-    nonNullable: true,
-    nonNullableStrict: true
-  }],
+  defaultOptions: DEFAULT_OPTIONS,
   meta: {
     type: 'suggestion',
     docs: {
@@ -92,22 +94,16 @@ export const preferType = createRule<[Options], MessageIds>({
     }
   },
   create: (context) => {
-    const userOptions = context.options[0] || {};
+    const ctxOptions = context.options[0] ?? {};
     const options = {
-      string: userOptions.string ?? true,
-      number: userOptions.number ?? true,
-      boolean: userOptions.boolean ?? true,
-      function: userOptions.function ?? true,
-      object: userOptions.object ?? true,
-      null: userOptions.null ?? false,
-      undefined: userOptions.undefined ?? false,
-      nullable: userOptions.nullable ?? true,
-      nonNullable: userOptions.nonNullable ?? true,
-      nonNullableStrict: userOptions.nonNullableStrict ?? true
+      ...DEFAULT_OPTIONS[0],
+      ...ctxOptions
     };
+
     const importName = 'Type';
     const modulePath = '@ephox/katamari';
     const sourceCode = context.sourceCode;
+    let importFixAdded = false;
 
     // Type check configurations for typeof checks
     const typeofChecks: Record<string, TypeCheckConfig> = {
@@ -168,10 +164,11 @@ export const preferType = createRule<[Options], MessageIds>({
      * Generate import statement if needed
      */
     const generateImportFix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix | null => {
-      if (hasTypeImport()) {
+      if (importFixAdded || hasTypeImport()) {
         return null; // Return null instead of empty array when no fix is needed
       }
 
+      importFixAdded = true;
       const program = sourceCode.ast;
       const imports = program.body.filter((node) => node.type === AST_NODE_TYPES.ImportDeclaration);
 
@@ -216,22 +213,24 @@ export const preferType = createRule<[Options], MessageIds>({
     };
 
     /**
-     * Handle typeof checks (e.g., typeof foo === 'string')
+     * Handle typeof checks (e.g., typeof foo === 'string' or 'string' === typeof foo)
      */
     const handleTypeofCheck = (node: TSESTree.BinaryExpression) => {
       const { left, operator, right } = node;
 
-      if (left.type === AST_NODE_TYPES.UnaryExpression && left.operator === 'typeof' &&
-          (operator === '===' || operator === '!==' || operator === '==' || operator === '!=') &&
-          right.type === AST_NODE_TYPES.Literal && typeof right.value === 'string') {
-
-        // Skip complex expressions that are not simple identifiers or member expressions
-        if (!isSimpleVariable(left.argument)) {
+      // Helper to check typeof pattern
+      const checkTypeofPattern = (typeofNode: TSESTree.Node, literalNode: TSESTree.Node) => {
+        if (typeofNode.type !== AST_NODE_TYPES.UnaryExpression || typeofNode.operator !== 'typeof' ||
+            literalNode.type !== AST_NODE_TYPES.Literal || typeof literalNode.value !== 'string') {
           return;
         }
 
-        const variable = getVariableName(left.argument);
-        const typeValue = right.value;
+        if (!isSimpleVariable(typeofNode.argument)) {
+          return;
+        }
+
+        const variable = getVariableName(typeofNode.argument);
+        const typeValue = literalNode.value;
         const isNegated = operator === '!==' || operator === '!=';
         const config = typeofChecks[typeValue];
 
@@ -240,6 +239,13 @@ export const preferType = createRule<[Options], MessageIds>({
           const replacement = isNegated ? `!${importName}.${config.func}(${variable})` : `${importName}.${config.func}(${variable})`;
           report(node, messageId, { variable }, config.optionKey, replacement);
         }
+      };
+
+      // Check for: typeof value === 'string'
+      if ((operator === '===' || operator === '!==' || operator === '==' || operator === '!=')) {
+        checkTypeofPattern(left, right);
+        // Check for: 'string' === typeof value (reversed operands)
+        checkTypeofPattern(right, left);
       }
     };
 

--- a/src/main/ts/rules/PreferKatamariType.ts
+++ b/src/main/ts/rules/PreferKatamariType.ts
@@ -25,6 +25,13 @@ type MessageIds = 'preferTypeString' | 'preferTypeNumber' | 'preferTypeBoolean' 
                  'negatedPreferTypeString' | 'negatedPreferTypeNumber' | 'negatedPreferTypeBoolean' | 'negatedPreferTypeFunction' |
                  'negatedPreferTypeObject' | 'negatedPreferTypeNull' | 'negatedPreferTypeUndefined';
 
+interface TypeCheckConfig {
+  func: string;
+  messageId: MessageIds;
+  negatedMessageId: MessageIds;
+  optionKey: keyof Options;
+}
+
 export const preferType = createRule<[Options], MessageIds>({
   name: 'prefer-katamari-type',
   defaultOptions: [{
@@ -102,7 +109,19 @@ export const preferType = createRule<[Options], MessageIds>({
     const modulePath = '@ephox/katamari';
     const sourceCode = context.sourceCode;
 
-    const report = (node: TSESTree.Node, messageId: MessageIds, data: Record<string, string>, optionKey: keyof typeof options, replacement: string) => {
+    // Type check configurations for typeof checks
+    const typeofChecks: Record<string, TypeCheckConfig> = {
+      string: { func: 'isString', messageId: 'preferTypeString', negatedMessageId: 'negatedPreferTypeString', optionKey: 'string' },
+      number: { func: 'isNumber', messageId: 'preferTypeNumber', negatedMessageId: 'negatedPreferTypeNumber', optionKey: 'number' },
+      boolean: { func: 'isBoolean', messageId: 'preferTypeBoolean', negatedMessageId: 'negatedPreferTypeBoolean', optionKey: 'boolean' },
+      function: { func: 'isFunction', messageId: 'preferTypeFunction', negatedMessageId: 'negatedPreferTypeFunction', optionKey: 'function' },
+      object: { func: 'isObject', messageId: 'preferTypeObject', negatedMessageId: 'negatedPreferTypeObject', optionKey: 'object' }
+    };
+
+    /**
+     * Report a violation if the option is enabled
+     */
+    const report = (node: TSESTree.Node, messageId: MessageIds, data: Record<string, string>, optionKey: keyof Options, replacement: string) => {
       if (options[optionKey] === true) {
         context.report({
           node,
@@ -117,6 +136,12 @@ export const preferType = createRule<[Options], MessageIds>({
      * Get the variable name from a node (handles complex expressions)
      */
     const getVariableName = (node: TSESTree.Node): string => sourceCode.getText(node);
+
+    /**
+     * Check if node is a simple identifier or member expression
+     */
+    const isSimpleVariable = (node: TSESTree.Node): boolean =>
+      node.type === AST_NODE_TYPES.Identifier || node.type === AST_NODE_TYPES.MemberExpression;
 
     /**
      * Check if there's already a Type import in the file
@@ -190,40 +215,142 @@ export const preferType = createRule<[Options], MessageIds>({
       }
     };
 
+    /**
+     * Handle typeof checks (e.g., typeof foo === 'string')
+     */
+    const handleTypeofCheck = (node: TSESTree.BinaryExpression) => {
+      const { left, operator, right } = node;
+
+      if (left.type === AST_NODE_TYPES.UnaryExpression && left.operator === 'typeof' &&
+          (operator === '===' || operator === '!==' || operator === '==' || operator === '!=') &&
+          right.type === AST_NODE_TYPES.Literal && typeof right.value === 'string') {
+
+        // Skip complex expressions that are not simple identifiers or member expressions
+        if (!isSimpleVariable(left.argument)) {
+          return;
+        }
+
+        const variable = getVariableName(left.argument);
+        const typeValue = right.value;
+        const isNegated = operator === '!==' || operator === '!=';
+        const config = typeofChecks[typeValue];
+
+        if (config) {
+          const messageId = isNegated ? config.negatedMessageId : config.messageId;
+          const replacement = isNegated ? `!${importName}.${config.func}(${variable})` : `${importName}.${config.func}(${variable})`;
+          report(node, messageId, { variable }, config.optionKey, replacement);
+        }
+      }
+    };
+
+    /**
+     * Handle null checks (e.g., foo === null, foo !== null)
+     */
+    const handleNullCheck = (node: TSESTree.BinaryExpression) => {
+      const { left, operator, right } = node;
+
+      if (((isSimpleVariable(left) && right.type === AST_NODE_TYPES.Literal && right.value === null) ||
+           (left.type === AST_NODE_TYPES.Literal && left.value === null && isSimpleVariable(right))) &&
+          (operator === '===' || operator === '!==')) {
+
+        const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
+        const isNegated = operator === '!==';
+        const messageId = isNegated ? 'negatedPreferTypeNull' : 'preferTypeNull';
+        const replacement = isNegated ? `!${importName}.isNull(${variable})` : `${importName}.isNull(${variable})`;
+
+        report(node, messageId, { variable }, 'null', replacement);
+      }
+    };
+
+    /**
+     * Handle undefined checks (e.g., foo === undefined, foo !== undefined)
+     */
+    const handleUndefinedCheck = (node: TSESTree.BinaryExpression) => {
+      const { left, operator, right } = node;
+
+      if (((isSimpleVariable(left) && right.type === AST_NODE_TYPES.Identifier && right.name === 'undefined') ||
+           (left.type === AST_NODE_TYPES.Identifier && left.name === 'undefined' && isSimpleVariable(right))) &&
+          (operator === '===' || operator === '!==')) {
+
+        const variable = (left.type === AST_NODE_TYPES.Identifier && left.name === 'undefined') ? getVariableName(right) : getVariableName(left);
+        const isNegated = operator === '!==';
+        const messageId = isNegated ? 'negatedPreferTypeUndefined' : 'preferTypeUndefined';
+        const replacement = isNegated ? `!${importName}.isUndefined(${variable})` : `${importName}.isUndefined(${variable})`;
+
+        report(node, messageId, { variable }, 'undefined', replacement);
+      }
+    };
+
+    /**
+     * Handle nullable checks (e.g., foo == null, foo != null)
+     */
+    const handleNullableCheck = (node: TSESTree.BinaryExpression) => {
+      const { left, operator, right } = node;
+
+      if (((isSimpleVariable(left) && right.type === AST_NODE_TYPES.Literal && right.value === null) ||
+           (left.type === AST_NODE_TYPES.Literal && left.value === null && isSimpleVariable(right))) &&
+          (operator === '==' || operator === '!=')) {
+
+        const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
+
+        if (operator === '==') {
+          const replacement = `${importName}.isNullable(${variable})`;
+          report(node, 'preferTypeNullable', { variable }, 'nullable', replacement);
+        } else if (operator === '!=') {
+          const replacement = `${importName}.isNonNullable(${variable})`;
+          report(node, 'preferTypeNonNullable', { variable }, 'nonNullable', replacement);
+        }
+      }
+    };
+
+    /**
+     * Check if a logical expression is the strict non-nullable pattern
+     */
+    const isStrictNonNullablePattern = (node: TSESTree.LogicalExpression): { variable: string } | null => {
+      if (node.operator !== '&&' ||
+          node.left.type !== AST_NODE_TYPES.BinaryExpression || node.left.operator !== '!==' ||
+          node.right.type !== AST_NODE_TYPES.BinaryExpression || node.right.operator !== '!==') {
+        return null;
+      }
+
+      let variable1: string | null = null;
+      let variable2: string | null = null;
+      let hasNullCheck = false;
+      let hasUndefinedCheck = false;
+
+      // Check left side: foo !== null
+      if (node.left.right.type === AST_NODE_TYPES.Literal && node.left.right.value === null) {
+        variable1 = getVariableName(node.left.left);
+        hasNullCheck = true;
+      } else if (node.left.left.type === AST_NODE_TYPES.Literal && node.left.left.value === null) {
+        variable1 = getVariableName(node.left.right);
+        hasNullCheck = true;
+      }
+
+      // Check right side: foo !== undefined
+      if (node.right.right.type === AST_NODE_TYPES.Identifier && node.right.right.name === 'undefined') {
+        variable2 = getVariableName(node.right.left);
+        hasUndefinedCheck = true;
+      } else if (node.right.left.type === AST_NODE_TYPES.Identifier && node.right.left.name === 'undefined') {
+        variable2 = getVariableName(node.right.right);
+        hasUndefinedCheck = true;
+      }
+
+      // If both checks are on the same variable and cover null and undefined
+      if (hasNullCheck && hasUndefinedCheck && variable1 === variable2 && variable1) {
+        return { variable: variable1 };
+      }
+
+      return null;
+    };
+
     return {
       LogicalExpression: (node) => {
-        // foo !== null && foo !== undefined -> Type.isNonNullable(foo)
-        // Handle this with higher priority to avoid conflicts with individual binary expressions
-        if (node.operator === '&&' &&
-          node.left.type === AST_NODE_TYPES.BinaryExpression && node.left.operator === '!==' &&
-          node.right.type === AST_NODE_TYPES.BinaryExpression && node.right.operator === '!==') {
-
-          let variable1; let variable2; let isNullCheck = false; let isUndefinedCheck = false;
-
-          // Check left side: foo !== null
-          if (node.left.right.type === AST_NODE_TYPES.Literal && node.left.right.value === null) {
-            variable1 = getVariableName(node.left.left);
-            isNullCheck = true;
-          } else if (node.left.left.type === AST_NODE_TYPES.Literal && node.left.left.value === null) {
-            variable1 = getVariableName(node.left.right);
-            isNullCheck = true;
-          }
-
-          // Check right side: foo !== undefined
-          if (node.right.right.type === AST_NODE_TYPES.Identifier && node.right.right.name === 'undefined') {
-            variable2 = getVariableName(node.right.left);
-            isUndefinedCheck = true;
-          } else if (node.right.left.type === AST_NODE_TYPES.Identifier && node.right.left.name === 'undefined') {
-            variable2 = getVariableName(node.right.right);
-            isUndefinedCheck = true;
-          }
-
-          // If both checks are on the same variable and cover null and undefined
-          if (isNullCheck && isUndefinedCheck && variable1 === variable2 && variable1) {
-            const replacement = `${importName}.isNonNullable(${variable1})`;
-            report(node, 'preferTypeNonNullableStrict', { variable: variable1 }, 'nonNullableStrict', replacement);
-            return; // Don't process child binary expressions
-          }
+        // Handle foo !== null && foo !== undefined -> Type.isNonNullable(foo)
+        const pattern = isStrictNonNullablePattern(node);
+        if (pattern) {
+          const replacement = `${importName}.isNonNullable(${pattern.variable})`;
+          report(node, 'preferTypeNonNullableStrict', { variable: pattern.variable }, 'nonNullableStrict', replacement);
         }
       },
 
@@ -231,98 +358,16 @@ export const preferType = createRule<[Options], MessageIds>({
         // Skip if this binary expression is part of a logical expression we've already handled
         if (node.parent && node.parent.type === AST_NODE_TYPES.LogicalExpression) {
           const parent = node.parent;
-          if (parent.operator === '&&' &&
-            parent.left.type === AST_NODE_TYPES.BinaryExpression && parent.left.operator === '!==' &&
-            parent.right.type === AST_NODE_TYPES.BinaryExpression && parent.right.operator === '!==') {
-            // Let the LogicalExpression handler deal with this
-            return;
-          }
-        }
-        const { left, operator, right } = node;
-
-        // typeof checks: typeof foo === 'string', typeof foo !== 'string'
-        if (left.type === AST_NODE_TYPES.UnaryExpression && left.operator === 'typeof' &&
-          (operator === '===' || operator === '!==' || operator === '==' || operator === '!=') &&
-          right.type === AST_NODE_TYPES.Literal && typeof right.value === 'string') {
-
-          // Skip complex expressions that are not simple identifiers or member expressions
-          if (left.argument.type !== AST_NODE_TYPES.Identifier && left.argument.type !== AST_NODE_TYPES.MemberExpression) {
-            return;
-          }
-
-          const variable = getVariableName(left.argument);
-          const typeValue = right.value;
-          const isNegated = operator === '!==' || operator === '!=';
-
-          type MessageId = 'preferTypeString' | 'preferTypeNumber' | 'preferTypeBoolean' | 'preferTypeFunction' | 'preferTypeObject' |
-            'negatedPreferTypeString' | 'negatedPreferTypeNumber' | 'negatedPreferTypeBoolean' | 'negatedPreferTypeFunction' | 'negatedPreferTypeObject';
-
-          const typeMap: Record<string, { func: string; messageId: MessageId; optionKey: keyof typeof options }> = {
-            string: { func: 'isString', messageId: isNegated ? 'negatedPreferTypeString' : 'preferTypeString', optionKey: 'string' },
-            number: { func: 'isNumber', messageId: isNegated ? 'negatedPreferTypeNumber' : 'preferTypeNumber', optionKey: 'number' },
-            boolean: { func: 'isBoolean', messageId: isNegated ? 'negatedPreferTypeBoolean' : 'preferTypeBoolean', optionKey: 'boolean' },
-            function: { func: 'isFunction', messageId: isNegated ? 'negatedPreferTypeFunction' : 'preferTypeFunction', optionKey: 'function' },
-            object: { func: 'isObject', messageId: isNegated ? 'negatedPreferTypeObject' : 'preferTypeObject', optionKey: 'object' }
-          };
-
-          if (typeMap[typeValue]) {
-            const { func, messageId, optionKey } = typeMap[typeValue];
-            const replacement = isNegated ? `!${importName}.${func}(${variable})` : `${importName}.${func}(${variable})`;
-
-            report(node, messageId, { variable }, optionKey, replacement);
+          if (isStrictNonNullablePattern(parent)) {
+            return; // Let the LogicalExpression handler deal with this
           }
         }
 
-        // null checks: foo === null, foo !== null
-        if (((left.type === AST_NODE_TYPES.Identifier || left.type === AST_NODE_TYPES.MemberExpression) &&
-          right.type === AST_NODE_TYPES.Literal && right.value === null) ||
-          (left.type === AST_NODE_TYPES.Literal && left.value === null &&
-            (right.type === AST_NODE_TYPES.Identifier || right.type === AST_NODE_TYPES.MemberExpression))) {
-
-          const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
-          const isNegated = operator === '!==';
-
-          if (operator === '===' || operator === '!==') {
-            const messageId = isNegated ? 'negatedPreferTypeNull' : 'preferTypeNull';
-            const replacement = isNegated ? `!${importName}.isNull(${variable})` : `${importName}.isNull(${variable})`;
-
-            report(node, messageId, { variable }, 'null', replacement);
-          }
-        }
-
-        // undefined checks: foo === undefined, foo !== undefined
-        if (((left.type === AST_NODE_TYPES.Identifier || left.type === AST_NODE_TYPES.MemberExpression) &&
-          right.type === AST_NODE_TYPES.Identifier && right.name === 'undefined') ||
-          (left.type === AST_NODE_TYPES.Identifier && left.name === 'undefined' &&
-            (right.type === AST_NODE_TYPES.Identifier || right.type === AST_NODE_TYPES.MemberExpression))) {
-
-          const variable = (left.type === AST_NODE_TYPES.Identifier && left.name === 'undefined') ? getVariableName(right) : getVariableName(left);
-          const isNegated = operator === '!==';
-
-          if (operator === '===' || operator === '!==') {
-            const messageId = isNegated ? 'negatedPreferTypeUndefined' : 'preferTypeUndefined';
-            const replacement = isNegated ? `!${importName}.isUndefined(${variable})` : `${importName}.isUndefined(${variable})`;
-
-            report(node, messageId, { variable }, 'undefined', replacement);
-          }
-        }
-
-        // nullable checks: foo == null, foo != null
-        if (((left.type === AST_NODE_TYPES.Identifier || left.type === AST_NODE_TYPES.MemberExpression) &&
-          right.type === AST_NODE_TYPES.Literal && right.value === null) ||
-          (left.type === AST_NODE_TYPES.Literal && left.value === null &&
-            (right.type === AST_NODE_TYPES.Identifier || right.type === AST_NODE_TYPES.MemberExpression))) {
-
-          const variable = left.type === AST_NODE_TYPES.Literal ? getVariableName(right) : getVariableName(left);
-
-          if (operator === '==') {
-            const replacement = `${importName}.isNullable(${variable})`;
-            report(node, 'preferTypeNullable', { variable }, 'nullable', replacement);
-          } else if (operator === '!=') {
-            const replacement = `${importName}.isNonNullable(${variable})`;
-            report(node, 'preferTypeNonNullable', { variable }, 'nonNullable', replacement);
-          }
-        }
+        // Handle different types of binary expressions
+        handleTypeofCheck(node);
+        handleNullCheck(node);
+        handleUndefinedCheck(node);
+        handleNullableCheck(node);
       }
     };
   }

--- a/src/test/rules/PreferKatamariTypeTest.ts
+++ b/src/test/rules/PreferKatamariTypeTest.ts
@@ -74,18 +74,13 @@ ruleTester.run('prefer-katamari-type', preferType, {
       code: 'value != null',
       options: [{ nonNullable: false }]
     },
-    // Test that null and undefined checks are ignored by default
     {
-      code: 'value === null'
+      code: 'value !== null',
+      options: [{ null: false }]
     },
     {
-      code: 'value !== null'
-    },
-    {
-      code: 'value === undefined'
-    },
-    {
-      code: 'value !== undefined'
+      code: 'value !== undefined',
+      options: [{ undefined: false }]
     }
   ],
   invalid: [
@@ -175,11 +170,66 @@ if (!Type.isString(value)) {
     },
     {
       code: `
+      if (typeof count !== 'number') {
+        throw new Error('Expected number');
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeNumber' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isNumber(count)) {
+        throw new Error('Expected number');
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof flag !== 'boolean') {
+        throw new Error('Expected boolean');
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeBoolean' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isBoolean(flag)) {
+        throw new Error('Expected boolean');
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof callback !== 'function') {
+        throw new Error('Expected function');
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeFunction' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isFunction(callback)) {
+        throw new Error('Expected function');
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof obj !== 'object') {
+        throw new Error('Expected object');
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeObject' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isObject(obj)) {
+        throw new Error('Expected object');
+      }
+      `
+    },
+    {
+      code: `
       if (value === null) {
         return 'null value';
       }
       `,
-      options: [{ null: true }],
       errors: [{ messageId: 'preferTypeNull' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -194,7 +244,6 @@ if (Type.isNull(value)) {
         return value.toString();
       }
       `,
-      options: [{ null: true }],
       errors: [{ messageId: 'negatedPreferTypeNull' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -209,7 +258,6 @@ if (!Type.isNull(value)) {
         return 'undefined value';
       }
       `,
-      options: [{ undefined: true }],
       errors: [{ messageId: 'preferTypeUndefined' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -224,7 +272,6 @@ if (Type.isUndefined(value)) {
         return value.toString();
       }
       `,
-      options: [{ undefined: true }],
       errors: [{ messageId: 'negatedPreferTypeUndefined' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -275,6 +322,121 @@ if (Type.isNonNullable(value)) {
       }
       `
     },
+    // Test reverse operand order for typeof checks
+    {
+      code: `
+      if ('string' === typeof value) {
+        console.log('is string');
+      }
+      `,
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isString(value)) {
+        console.log('is string');
+      }
+      `
+    },
+    {
+      code: `
+      if ('number' !== typeof count) {
+        throw new Error('Expected number');
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeNumber' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isNumber(count)) {
+        throw new Error('Expected number');
+      }
+      `
+    },
+    // Test null/undefined with reversed operands
+    {
+      code: `
+      if (null === value) {
+        return 'null value';
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNull' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNull(value)) {
+        return 'null value';
+      }
+      `
+    },
+    {
+      code: `
+      if (null !== value) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeNull' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isNull(value)) {
+        return value.toString();
+      }
+      `
+    },
+    {
+      code: `
+      if (undefined === value) {
+        return 'undefined value';
+      }
+      `,
+      errors: [{ messageId: 'preferTypeUndefined' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isUndefined(value)) {
+        return 'undefined value';
+      }
+      `
+    },
+    {
+      code: `
+      if (undefined !== value) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeUndefined' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isUndefined(value)) {
+        return value.toString();
+      }
+      `
+    },
+    {
+      code: `
+      if (null == value) {
+        return 'nullable';
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNullable' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNullable(value)) {
+        return 'nullable';
+      }
+      `
+    },
+    {
+      code: `
+      if (null != value) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNonNullable' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNonNullable(value)) {
+        return value.toString();
+      }
+      `
+    },
+    // Test with and without import
     {
       code: `
       import { Type } from '@ephox/katamari';
@@ -296,11 +458,17 @@ if (Type.isNonNullable(value)) {
       if (typeof value === 'string') {
         console.log('already has import');
       }
+      if (typeof value === 'number') {
+        console.log('already has import');
+      }
       `,
-      errors: [{ messageId: 'preferTypeString' }],
+      errors: [{ messageId: 'preferTypeString' }, { messageId: 'preferTypeNumber' }],
       output: `
       import { Arr, Type } from '@ephox/katamari';
       if (Type.isString(value)) {
+        console.log('already has import');
+      }
+      if (Type.isNumber(value)) {
         console.log('already has import');
       }
       `
@@ -308,15 +476,15 @@ if (Type.isNonNullable(value)) {
     {
       code: `
       import { Something } from '@other/package';
-      if (typeof value === 'string') {
+      if (typeof value === 'boolean') {
         console.log('has other imports');
       }
       `,
-      errors: [{ messageId: 'preferTypeString' }],
+      errors: [{ messageId: 'preferTypeBoolean' }],
       output: `
       import { Something } from '@other/package';
 import { Type } from '@ephox/katamari';
-      if (Type.isString(value)) {
+      if (Type.isBoolean(value)) {
         console.log('has other imports');
       }
       `

--- a/src/test/rules/PreferKatamariTypeTest.ts
+++ b/src/test/rules/PreferKatamariTypeTest.ts
@@ -1,0 +1,276 @@
+import tsParser from '@typescript-eslint/parser';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { preferType } from '../../main/ts/rules/PreferKatamariType';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    parserOptions: { sourceType: 'module' }
+  }
+});
+
+ruleTester.run('prefer-katamari-type', preferType, {
+  valid: [
+    {
+      code: `
+      import { Type } from '@ephox/katamari';
+      if (Type.isString(value)) {
+        console.log('is string');
+      }
+      `
+    },
+    {
+      code: `
+      import { Type } from '@ephox/katamari';
+      const result = Type.isNumber(x) && !Type.isNull(y);
+      `
+    },
+    {
+      code: `
+      import { Type } from '@ephox/katamari';
+      if (!Type.isNull(obj)) {
+        return obj.property;
+      }
+      `
+    },
+    {
+      code: `
+      // Complex expressions should not trigger the rule
+      if (typeof getValue() === 'string') {
+        console.log('complex expression');
+      }
+      `
+    }
+  ],
+  invalid: [
+    {
+      code: `
+      if (typeof value === 'string') {
+        console.log('is string');
+      }
+      `,
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isString(value)) {
+        console.log('is string');
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof count === 'number') {
+        return count + 1;
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNumber' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNumber(count)) {
+        return count + 1;
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof flag === 'boolean') {
+        return flag;
+      }
+      `,
+      errors: [{ messageId: 'preferTypeBoolean' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isBoolean(flag)) {
+        return flag;
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof callback === 'function') {
+        callback();
+      }
+      `,
+      errors: [{ messageId: 'preferTypeFunction' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isFunction(callback)) {
+        callback();
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof obj === 'object') {
+        return obj.prop;
+      }
+      `,
+      errors: [{ messageId: 'preferTypeObject' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isObject(obj)) {
+        return obj.prop;
+      }
+      `
+    },
+    {
+      code: `
+      if (typeof value !== 'string') {
+        throw new Error('Expected string');
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeString' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isString(value)) {
+        throw new Error('Expected string');
+      }
+      `
+    },
+    {
+      code: `
+      if (value === null) {
+        return 'null value';
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNull' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNull(value)) {
+        return 'null value';
+      }
+      `
+    },
+    {
+      code: `
+      if (value !== null) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeNull' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isNull(value)) {
+        return value.toString();
+      }
+      `
+    },
+    {
+      code: `
+      if (value === undefined) {
+        return 'undefined value';
+      }
+      `,
+      errors: [{ messageId: 'preferTypeUndefined' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isUndefined(value)) {
+        return 'undefined value';
+      }
+      `
+    },
+    {
+      code: `
+      if (value !== undefined) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'negatedPreferTypeUndefined' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (!Type.isUndefined(value)) {
+        return value.toString();
+      }
+      `
+    },
+    {
+      code: `
+      if (value == null) {
+        return 'nullable';
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNullable' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNullable(value)) {
+        return 'nullable';
+      }
+      `
+    },
+    {
+      code: `
+      if (value != null) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNonNullable' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNonNullable(value)) {
+        return value.toString();
+      }
+      `
+    },
+    {
+      code: `
+      if (value !== null && value !== undefined) {
+        return value.toString();
+      }
+      `,
+      errors: [{ messageId: 'preferTypeNonNullableStrict' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+if (Type.isNonNullable(value)) {
+        return value.toString();
+      }
+      `
+    },
+    {
+      code: `
+      import { Type } from '@ephox/katamari';
+      if (typeof value === 'string') {
+        console.log('already has import');
+      }
+      `,
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+      if (Type.isString(value)) {
+        console.log('already has import');
+      }
+      `
+    },
+    {
+      code: `
+      import { Something } from '@other/package';
+      if (typeof value === 'string') {
+        console.log('has other imports');
+      }
+      `,
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `
+      import { Something } from '@other/package';
+import { Type } from '@ephox/katamari';
+      if (Type.isString(value)) {
+        console.log('has other imports');
+      }
+      `
+    },
+    {
+      code: `
+      const obj = { prop: 'value' };
+      if (typeof obj.prop === 'string') {
+        console.log('member expression');
+      }
+      `,
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `
+      import { Type } from '@ephox/katamari';
+const obj = { prop: 'value' };
+      if (Type.isString(obj.prop)) {
+        console.log('member expression');
+      }
+      `
+    }
+  ]
+});

--- a/src/test/rules/PreferKatamariTypeTest.ts
+++ b/src/test/rules/PreferKatamariTypeTest.ts
@@ -40,6 +40,52 @@ ruleTester.run('prefer-katamari-type', preferType, {
         console.log('complex expression');
       }
       `
+    },
+    // Test configurable options - these should not trigger when disabled
+    {
+      code: 'typeof value === "string"',
+      options: [{ string: false }]
+    },
+    {
+      code: 'typeof value === "number"',
+      options: [{ number: false }]
+    },
+    {
+      code: 'typeof value === "boolean"',
+      options: [{ boolean: false }]
+    },
+    {
+      code: 'typeof value === "function"',
+      options: [{ function: false }]
+    },
+    {
+      code: 'value === null',
+      options: [{ null: false }]
+    },
+    {
+      code: 'value === undefined',
+      options: [{ undefined: false }]
+    },
+    {
+      code: 'value == null',
+      options: [{ nullable: false }]
+    },
+    {
+      code: 'value != null',
+      options: [{ nonNullable: false }]
+    },
+    // Test that null and undefined checks are ignored by default
+    {
+      code: 'value === null'
+    },
+    {
+      code: 'value !== null'
+    },
+    {
+      code: 'value === undefined'
+    },
+    {
+      code: 'value !== undefined'
     }
   ],
   invalid: [
@@ -133,6 +179,7 @@ if (!Type.isString(value)) {
         return 'null value';
       }
       `,
+      options: [{ null: true }],
       errors: [{ messageId: 'preferTypeNull' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -147,6 +194,7 @@ if (Type.isNull(value)) {
         return value.toString();
       }
       `,
+      options: [{ null: true }],
       errors: [{ messageId: 'negatedPreferTypeNull' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -161,6 +209,7 @@ if (!Type.isNull(value)) {
         return 'undefined value';
       }
       `,
+      options: [{ undefined: true }],
       errors: [{ messageId: 'preferTypeUndefined' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -175,6 +224,7 @@ if (Type.isUndefined(value)) {
         return value.toString();
       }
       `,
+      options: [{ undefined: true }],
       errors: [{ messageId: 'negatedPreferTypeUndefined' }],
       output: `
       import { Type } from '@ephox/katamari';
@@ -242,6 +292,21 @@ if (Type.isNonNullable(value)) {
     },
     {
       code: `
+      import { Arr } from '@ephox/katamari';
+      if (typeof value === 'string') {
+        console.log('already has import');
+      }
+      `,
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `
+      import { Arr, Type } from '@ephox/katamari';
+      if (Type.isString(value)) {
+        console.log('already has import');
+      }
+      `
+    },
+    {
+      code: `
       import { Something } from '@other/package';
       if (typeof value === 'string') {
         console.log('has other imports');
@@ -271,6 +336,14 @@ const obj = { prop: 'value' };
         console.log('member expression');
       }
       `
+    },
+    // Test that explicit enable works even when other options are disabled
+    {
+      code: 'typeof value === "string"',
+      options: [{ string: true, number: false, boolean: false }],
+      errors: [{ messageId: 'preferTypeString' }],
+      output: `import { Type } from '@ephox/katamari';
+Type.isString(value)`
     }
   ]
 });


### PR DESCRIPTION
Related Ticket: TINY-12772

Description of Changes:
* Add a custom eslint rule that suggests to use the Type module from katamari instead of manualy 'typeof' and individual `undefined` and `null` checks

Pre-checks:
* [X] Changelog entry added
* [X] package.json version bumped (if first change of new major/minor)
* [X] Tests have been added (if applicable)
